### PR TITLE
fix(apply-template): avoid ENOENT when removing landing directories

### DIFF
--- a/scripts/apply-template.ts
+++ b/scripts/apply-template.ts
@@ -666,8 +666,10 @@ function removeLandingPage(): number {
     if (!fs.existsSync(abs)) continue;
     const stat = fs.statSync(abs);
     if (stat.isDirectory()) {
-      if (!DRY_RUN) fs.rmSync(abs, { recursive: true, force: true });
+      // Count entries before deletion: reading the directory after rmSync()
+      // throws ENOENT in non-dry-run mode.
       removed += fs.readdirSync(abs).length;
+      if (!DRY_RUN) fs.rmSync(abs, { recursive: true, force: true });
     } else {
       if (!DRY_RUN) fs.unlinkSync(abs);
       removed++;


### PR DESCRIPTION
## Summary

Fix `pnpm apply-template` failing while removing the project landing page in non-dry-run mode.

## Problem

`removeLandingPage()` currently calls `fs.rmSync()` on a directory and then immediately calls `fs.readdirSync()` on the same path to count removed entries. After the directory is deleted, `readdirSync()` throws `ENOENT`, interrupting the template setup flow.

## Fix

Count the directory entries before deleting the directory. Dry-run behavior and the returned count stay unchanged.

## Validation

- `pnpm lint` ✅
- `pnpm typecheck` / `astro check` ✅ (0 errors)
- `pnpm test` ✅ (96 tests)
- Regression check: count entries before `rmSync()` and verify deletion completes without `ENOENT` ✅

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation only