### PR TITLE
fix(docs): roadmap.md 版本头 v2.13.0→v2.15.1

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 > 本页回答两个问题:**这套模板过去按什么方向演化**(帮你判断它的成熟度和侧重),以及**接下来会往哪走**(帮你决定现在入场合不合适)。逐版本的完整变更见 [CHANGELOG](../CHANGELOG.md);正在做什么见 [PRD](./PRD.md) 第 14 章。
 
-> **当前版本:v2.13.0**(2026-09-02 发布)。发版历史与最新版本见 [Releases](https://github.com/PNGTRID/AnvilWiki/releases)。
+> **当前版本:v2.15.1**(2026-09-06 发布)。发版历史与最新版本见 [Releases](https://github.com/PNGTRID/AnvilWiki/releases)。
 
 ## 演化主线:从「建站模板」到「内容经营操作系统」
 


### PR DESCRIPTION
## 根因
roadmap.md 第 5 行「当前版本」头停在 v2.13.0(2026-09-02),其后 v2.14.0/v2.14.1/v2.15.0/v2.15.1 四个版本均未更新。属于已知类别:文档正文内嵌的版本数字不在自动门禁覆盖内(与 v2.6.x「demo 现状数字」教训同类)。

## 修复
单行:当前版本 v2.13.0 → v2.15.1(2026-09-06 发布)。

## 验证
- 纯文档单行改动,八门禁不涉代码;CHANGELOG [Unreleased] 指针、package.json、landing.ts PROJECT_VERSION 三处本就一致(每日巡检已核)。

## 建议(不在本 PR)
- 把 roadmap.md 版本头加入发版 SOP 检查清单与每日一致性扫描清单。
- 候选池「选品决策支持」一条已实质由 anvil-find-keywords(v2.15.0)覆盖,是否标注交付状态由维护者拍板。