### PR TITLE
feat(scripts): pnpm sync-codes——codes 页批量同步(管道生成器扩展第一步)

### DIFF
--- a/.agent/skills/anvil-update-codes/SKILL.md
+++ b/.agent/skills/anvil-update-codes/SKILL.md
@@ -25,10 +25,12 @@ ls src/content/wiki/en/codes/   # 或用户指定的 locale
 codes:
   - code: FORGE-2026
     reward: '+500 Gold'
-    status: active        # active | expired
+    status: active
     expiryDate: 'Aug 31'
     source: 'Official Discord announcement'
 ```
+
+(`status` 取值 `active | expired`;YAML 块内不要写行内注释——`pnpm sync-codes` 的解析器会响亮拒绝。)
 
 - 新码:在 `codes:` 数组 active 项最前面追加(带 reward/expiryDate)
 - 用户说"XX 过期了":把该项 `status` 改为 `expired`(保留,不删除——过期码是 "is X still working" 长尾 SEO 内容)

--- a/.agent/skills/anvil-update-codes/SKILL.md
+++ b/.agent/skills/anvil-update-codes/SKILL.md
@@ -37,6 +37,8 @@ codes:
 - `summary` 里的码数量/日期同步修正
 - 正文里的 CodeBlock 列表(旧格式)迁移到 frontmatter 后删除,正文保留 how-to-redeem 等散文内容
 
+> **批量场景**(一次新增/过期多个码):`pnpm sync-codes` 读 `codes-sync.csv` 确定性合并进 frontmatter(`--dry-run` 预览,新码前置/过期保留,全语言同名页同步)。本技能仍是单页精修与翻译判断(reward 等文案按语言译)的正道。
+
 ### Step 3 — 多语言同步
 
 若 `src/content/wiki/<locale>/codes/` 存在同名文章,同步数据(codes frontmatter 的 `code` 字段不翻译,`reward` 等文案字段翻译)。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@ pnpm gen-assets       # scripts/gen-assets.ts — regenerate favicon set + hero.
 pnpm submit-indexnow  # scripts/submit-indexnow.ts — push all dist/ sitemap URLs to IndexNow (run after build+deploy; first run generates the key file)
 pnpm template-audit   # scripts/template-audit.ts — template health check (code purity / rebrand leftovers / health score)
 pnpm bulk-new-posts   # scripts/bulk-new-posts.ts — batch-create draft MDX from a new-posts.csv keyword list (--dry-run preview)
+pnpm sync-codes       # scripts/sync-codes.ts — batch-apply a codes-sync.csv into codes pages' frontmatter codes array (add/expire; --dry-run preview)
 pnpm refresh-audit    # scripts/refresh-audit.ts — deterministic freshness report (codes pages >7d, stale categories >90d)
 pnpm apply-template   # interactive template-apply CLI (hex→HSL theme, rewrite config/locales)
 pnpm new-post         # interactive MDX article scaffold

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ pnpm dev              # dev server, http://localhost:4321
 pnpm build            # includes Content schema validation — fails on bad frontmatter; postbuild indexes Pagefind search
 pnpm typecheck        # astro check (0 errors expected)
 pnpm lint             # ESLint (eslint-plugin-astro)
-pnpm test             # Vitest — 11 suites (url, seo, tags, i18n-smoke, content-utils, handbook, workflows, covers, affiliates, prompt, apply-template)
+pnpm test             # Vitest — 12 suites (url, seo, tags, i18n-smoke, content-utils, handbook, workflows, covers, affiliates, prompt, apply-template, sync-codes)
 pnpm test:e2e         # apply-template real-mode E2E (git archive → scratch copy → pipe answers → assert shape → build; CI job e2e-template runs it; tests the COMMITTED tree)
 pnpm check-config     # scripts/check-config.ts — nav/locale 3-place consistency
 pnpm new-locale       # scripts/new-locale.ts — scaffold a new language

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`pnpm sync-codes`:codes 页批量同步脚本(第 15 个运维脚本,管道生成器扩展第一步)**——读仓库根 `codes-sync.csv`(`locale,slug,code,status,reward,expiryDate,source`,CSV/TSV 自适应,`--dry-run` 预览),确定性合并进已有 codes 页的 frontmatter `codes:` 数组:新码前置、过期翻转但保留(长尾 SEO)、空可选单元格保留现值、全语言同名页同步(码不翻译,reward/source 照搬需人工复查非 en 措辞);合并语义与 anvil-update-codes 技能逐条对齐,是该技能的机械半边;先全量校验后写入(all-or-nothing),扁平标量解析器遇到未知字段/行内注释/嵌套结构响亮中止绝不盲写,lastModified 随写随更。纯函数下沉 `scripts/lib/sync-codes.ts`(第 12 套件 tests/sync-codes.test.ts,14 条,序列化逐字节钉死+幂等);CSV/TSV 解析器抽共享 `scripts/lib/delimited.ts`(bulk-new-posts 同源复用);目标页必须已存在,同步不建页。管道接入(auto-content.yml 任务输入+契约测试)留独立小版本(docs/content-pipeline.md 候选已标注)。文档同步:AGENTS 命令表/手册附录 C 双语(20→21 条)/content-pipeline 新节/PRD 脚本计数/anvil-update-codes 技能批量提示。
+
 ## [2.15.1] — 2026-09-06
 
 **anvil-find-keywords 技能收口：SKILL.md 与 docs/sourcing.md 逐字对齐（早期爆发轨具体阈值 + 英文手册路径），零代码行为变更。**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`pnpm sync-codes`:codes 页批量同步脚本(第 15 个运维脚本,管道生成器扩展第一步)**——读仓库根 `codes-sync.csv`(`locale,slug,code,status,reward,expiryDate,source`,CSV/TSV 自适应,`--dry-run` 预览),确定性合并进已有 codes 页的 frontmatter `codes:` 数组:新码前置、过期翻转但保留(长尾 SEO)、空可选单元格保留现值、全语言同名页同步(码不翻译,reward/source 照搬需人工复查非 en 措辞);合并语义与 anvil-update-codes 技能逐条对齐,是该技能的机械半边;先全量校验后写入(all-or-nothing),扁平标量解析器遇到未知字段/行内注释/嵌套结构响亮中止绝不盲写,lastModified 随写随更。纯函数下沉 `scripts/lib/sync-codes.ts`(第 12 套件 tests/sync-codes.test.ts,14 条,序列化逐字节钉死+幂等);CSV/TSV 解析器抽共享 `scripts/lib/delimited.ts`(bulk-new-posts 同源复用);目标页必须已存在,同步不建页。管道接入(auto-content.yml 任务输入+契约测试)留独立小版本(docs/content-pipeline.md 候选已标注)。文档同步:AGENTS 命令表/手册附录 C 双语(20→21 条)/content-pipeline 新节/PRD 脚本计数/anvil-update-codes 技能批量提示。
+- **`pnpm sync-codes`:codes 页批量同步脚本(第 15 个运维脚本,管道生成器扩展第一步)**——读仓库根 `codes-sync.csv`(`locale,slug,code,status,reward,expiryDate,source`,CSV/TSV 自适应,`--dry-run` 预览),确定性合并进已有 codes 页的 frontmatter `codes:` 数组:新码前置、过期翻转但保留(长尾 SEO)、空可选单元格保留现值、零改写页不重写(lastModified 是保鲜信号,无真实变更绝不空跳);**全语言同名页同步**——显式行优先(每语言可给翻译行),无行的语言自动跟随该 slug 首行 fan-out(码不翻译,reward/source 照搬需人工复查非 en 措辞,计划输出逐条提示);合并语义与 anvil-update-codes 技能逐条对齐,是该技能的机械半边;先全量校验后写入(all-or-nothing),扁平标量解析器遇到未知字段/行内注释/嵌套结构响亮中止绝不盲写,单元格含换行/控制字符解析期即拒(不写出非法 YAML),CRLF 页面兼容且保留原 EOL 风格,lastModified 随写随更。纯函数下沉 `scripts/lib/sync-codes.ts`(第 12 套件 tests/sync-codes.test.ts,含 fan-out/CRLF/控制字符/序列化幂等逐字节钉死);CSV/TSV 解析器抽共享 `scripts/lib/delimited.ts`(bulk-new-posts 同源复用);目标页必须已存在,同步不建页;未知 flag 一律报错(防 `--drry-run` 笔误静默真写)。管道接入(auto-content.yml 任务输入+契约测试)留独立小版本(docs/content-pipeline.md 候选已标注)。文档同步:AGENTS 命令表+套件计数/手册附录 C 双语(20→21 条)/content-pipeline 新节/PRD 脚本计数/anvil-update-codes 技能批量提示+示例去行内注释。
 
 ## [2.15.1] — 2026-09-06
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -339,7 +339,7 @@ anvilwiki/
 │   ├── styles/globals.css        # ⭐ --brand 4 变量（:root 4 行 + .dark 4 行）
 │   ├── assets/                   # 封面图等（走 astro:assets <Image> 管线，WebP+srcset）
 │   └── lib/                      # content.ts / content-utils.ts / navigation.ts / seo.ts / url.ts / handbook.ts
-├── scripts/                      # 14 个运维脚本（check-* ×5 + refresh-audit + new-locale/new-post + apply-template + template-audit + bulk-new-posts + gen-covers + gen-assets + submit-indexnow）
+├── scripts/                      # 15 个运维脚本（check-* ×5 + refresh-audit + new-locale/new-post + apply-template + template-audit + bulk-new-posts + sync-codes + gen-covers + gen-assets + submit-indexnow）
 ├── tools/anvil-ops/              # ⭐ 独立 npm 包 anvilwiki-ops（CLI + MCP，自有 workspace）
 ├── .agent/skills/                # ⭐ AI 内容技能（anvil-find-keywords / anvil-new-article / anvil-batch-articles / anvil-update-codes / anvil-refresh / anvil-adsense-audit）
 └── .github/

--- a/docs/content-pipeline.md
+++ b/docs/content-pipeline.md
@@ -63,8 +63,12 @@ merge → Cloudflare Pages 自动部署
 | 做什么 | 只读审计 → 开 issue 提醒「什么过期了」 | 确定性生成 → 八道门禁 → draft PR |
 | 改内容 | 从不改 | 只创建 `draft: true` 脚手架,真实内容仍由人/AI 本地会话填 |
 
+## codes 批量同步(本地,`pnpm sync-codes`)
+
+codes 页是更新频率最高的页面,`pnpm sync-codes` 把「新增/过期兑换码」变成一条确定性脚本:读一份 `codes-sync.csv`(`locale,slug,code,status,reward,expiryDate,source`),合并进已有 codes 页的 frontmatter `codes:` 数组——新码前置、过期翻转但保留(长尾 SEO)、空可选单元格保留现值;同名页面在所有语言同步(码不翻译,reward/source 文案照搬,非 en 语言需复查措辞)。合并语义与 `.agent/skills/anvil-update-codes` 一致,它是那套流程的机械半边;解析失败(未知字段/行内注释/嵌套结构)一律响亮中止,绝不盲写。先 `--dry-run` 预览。目标页必须已存在——同步不建页。
+
 ## v2.1 候选
 
-- `codes-sync` 生成器(从结构化数据源同步兑换码,仍走同一管道)
+- ✅ `codes-sync` 生成器(脚本本体已交付:`pnpm sync-codes`;剩余:接入 auto-content.yml 管道——新增任务输入 + workflows.test.ts 契约,单独小版本做)
 - issue 评论 `/generate` 触发(需 collaborator 校验,见 GitHub Actions 安全实践)
 - GitHub App token(让管道 PR 上的 CI 自动跑,而非待批准)

--- a/docs/content-pipeline.md
+++ b/docs/content-pipeline.md
@@ -65,7 +65,7 @@ merge → Cloudflare Pages 自动部署
 
 ## codes 批量同步(本地,`pnpm sync-codes`)
 
-codes 页是更新频率最高的页面,`pnpm sync-codes` 把「新增/过期兑换码」变成一条确定性脚本:读一份 `codes-sync.csv`(`locale,slug,code,status,reward,expiryDate,source`),合并进已有 codes 页的 frontmatter `codes:` 数组——新码前置、过期翻转但保留(长尾 SEO)、空可选单元格保留现值;同名页面在所有语言同步(码不翻译,reward/source 文案照搬,非 en 语言需复查措辞)。合并语义与 `.agent/skills/anvil-update-codes` 一致,它是那套流程的机械半边;解析失败(未知字段/行内注释/嵌套结构)一律响亮中止,绝不盲写。先 `--dry-run` 预览。目标页必须已存在——同步不建页。
+codes 页是更新频率最高的页面,`pnpm sync-codes` 把「新增/过期兑换码」变成一条确定性脚本:读一份 `codes-sync.csv`(`locale,slug,code,status,reward,expiryDate,source`),合并进已有 codes 页的 frontmatter `codes:` 数组——新码前置、过期翻转但保留(长尾 SEO)、空可选单元格保留现值;同名页面在所有语言同步(显式语言行优先,可按语言给翻译行;无行的语言自动跟随该 slug 首行,reward/source 文案照搬,非 en 语言需复查措辞)。合并语义与 `.agent/skills/anvil-update-codes` 一致,它是那套流程的机械半边;解析失败(未知字段/行内注释/嵌套结构)一律响亮中止,绝不盲写。先 `--dry-run` 预览。目标页必须已存在——同步不建页。
 
 ## v2.1 候选
 

--- a/docs/handbook/en/glossary-and-commands.md
+++ b/docs/handbook/en/glossary-and-commands.md
@@ -1,11 +1,11 @@
 ---
 title: "Appendix C · Glossary & Command Cheat Sheet"
-description: "Every word card in one place — 30+ terms by theme — plus twenty pnpm commands grouped by scenario: writing, QA, config, ops, assets."
+description: "Every word card in one place — 30+ terms by theme — plus twenty-one pnpm commands grouped by scenario: writing, QA, config, ops, assets."
 manual: learn
 order: 32
 stage: "Appendices"
 icon: lucide:book-marked
-tldr: "Two parts: ① the glossary — every lesson's word cards regrouped by theme (SEO & search / site & content / monetization & ops); ② the command sheet — pnpm commands by scenario: writing (new-post / bulk-new-posts), QA (check-content / check-links / build), config (check-config / apply-template / new-locale), ops (refresh-audit / submit-indexnow), assets (gen-covers / gen-assets). One line each — when detail fades, start here."
+tldr: "Two parts: ① the glossary — every lesson's word cards regrouped by theme (SEO & search / site & content / monetization & ops); ② the command sheet — pnpm commands by scenario: writing (new-post / bulk-new-posts / sync-codes), QA (check-content / check-links / build), config (check-config / apply-template / new-locale), ops (refresh-audit / submit-indexnow), assets (gen-covers / gen-assets). One line each — when detail fades, start here."
 updated: 2026-09-02
 ---
 
@@ -61,6 +61,7 @@ updated: 2026-09-02
 ```bash
 pnpm new-post           # interactive single-page scaffold
 pnpm bulk-new-posts     # batch drafts from a keyword CSV (--dry-run to preview)
+pnpm sync-codes         # batch-sync redeem codes from a CSV (--dry-run to preview)
 ```
 
 **QA (after every change)**

--- a/docs/handbook/en/glossary-and-commands.md
+++ b/docs/handbook/en/glossary-and-commands.md
@@ -6,7 +6,7 @@ order: 32
 stage: "Appendices"
 icon: lucide:book-marked
 tldr: "Two parts: ① the glossary — every lesson's word cards regrouped by theme (SEO & search / site & content / monetization & ops); ② the command sheet — pnpm commands by scenario: writing (new-post / bulk-new-posts / sync-codes), QA (check-content / check-links / build), config (check-config / apply-template / new-locale), ops (refresh-audit / submit-indexnow), assets (gen-covers / gen-assets). One line each — when detail fades, start here."
-updated: 2026-09-02
+updated: 2026-09-06
 ---
 
 ## Glossary (grouped by theme)

--- a/docs/handbook/zh/glossary-and-commands.md
+++ b/docs/handbook/zh/glossary-and-commands.md
@@ -6,7 +6,7 @@ order: 32
 stage: "附录"
 icon: lucide:book-marked
 tldr: "两部分:①术语表——各课词卡按主题归拢(SEO 类/站务类/变现类/工程类);②命令速查——pnpm 命令按场景分组:写作(new-post/bulk-new-posts/sync-codes)、质检(check-content/check-links/build)、配置(check-config/apply-template/new-locale)、运营(refresh-audit/submit-indexnow)、资产(gen-covers/gen-assets)。每条一句话说明,忘了细节先来这里。"
-updated: 2026-09-02
+updated: 2026-09-06
 ---
 
 ## 术语表(按主题归拢)

--- a/docs/handbook/zh/glossary-and-commands.md
+++ b/docs/handbook/zh/glossary-and-commands.md
@@ -1,11 +1,11 @@
 ---
 title: "附录 C · 术语表与命令速查"
-description: "全手册词卡的统一住处:30+ 个术语按拼音/字母排列;20 条 pnpm 命令按场景分组(写作/质检/配置/运营/资产),各带一句话说明。"
+description: "全手册词卡的统一住处:30+ 个术语按拼音/字母排列;21 条 pnpm 命令按场景分组(写作/质检/配置/运营/资产),各带一句话说明。"
 manual: learn
 order: 32
 stage: "附录"
 icon: lucide:book-marked
-tldr: "两部分:①术语表——各课词卡按主题归拢(SEO 类/站务类/变现类/工程类);②命令速查——pnpm 命令按场景分组:写作(new-post/bulk-new-posts)、质检(check-content/check-links/build)、配置(check-config/apply-template/new-locale)、运营(refresh-audit/submit-indexnow)、资产(gen-covers/gen-assets)。每条一句话说明,忘了细节先来这里。"
+tldr: "两部分:①术语表——各课词卡按主题归拢(SEO 类/站务类/变现类/工程类);②命令速查——pnpm 命令按场景分组:写作(new-post/bulk-new-posts/sync-codes)、质检(check-content/check-links/build)、配置(check-config/apply-template/new-locale)、运营(refresh-audit/submit-indexnow)、资产(gen-covers/gen-assets)。每条一句话说明,忘了细节先来这里。"
 updated: 2026-09-02
 ---
 
@@ -61,6 +61,7 @@ updated: 2026-09-02
 ```bash
 pnpm new-post           # 交互式单篇脚手架
 pnpm bulk-new-posts     # 从关键词 CSV 批量建草稿(--dry-run 预览)
+pnpm sync-codes         # 从 CSV 批量同步兑换码(新增/过期,--dry-run 预览)
 ```
 
 **质检(改完必跑)**

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "check-config": "tsx scripts/check-config.ts",
     "new-post": "tsx scripts/new-post.ts",
     "bulk-new-posts": "tsx scripts/bulk-new-posts.ts",
+    "sync-codes": "tsx scripts/sync-codes.ts",
     "gen-covers": "tsx scripts/gen-covers.ts",
     "gen-assets": "tsx scripts/gen-assets.ts",
     "submit-indexnow": "tsx scripts/submit-indexnow.ts",

--- a/scripts/bulk-new-posts.ts
+++ b/scripts/bulk-new-posts.ts
@@ -34,6 +34,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { isBlankOrComment, parseDelimited } from './lib/delimited';
 
 const ROOT = process.cwd();
 const CONTENT_BASE = path.resolve(ROOT, 'src/content/wiki');
@@ -93,48 +94,7 @@ function todayIso(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
-/** Minimal RFC-4180-ish delimited parser: quoted fields, "" escapes, CSV or TSV.
- * Reports an unterminated quote instead of silently swallowing the file tail. */
-function parseDelimited(text: string): { rows: string[][]; unterminatedQuote: boolean } {
-  const firstLine = text.slice(0, text.indexOf('\n') === -1 ? text.length : text.indexOf('\n'));
-  const delim = firstLine.includes('\t') && !firstLine.includes(',') ? '\t' : ',';
-  const rows: string[][] = [];
-  let row: string[] = [];
-  let field = '';
-  let inQuotes = false;
-  for (let i = 0; i < text.length; i++) {
-    const c = text[i];
-    if (inQuotes) {
-      if (c === '"') {
-        if (text[i + 1] === '"') {
-          field += '"';
-          i++;
-        } else {
-          inQuotes = false;
-        }
-      } else {
-        field += c;
-      }
-    } else if (c === '"') {
-      inQuotes = true;
-    } else if (c === delim) {
-      row.push(field);
-      field = '';
-    } else if (c === '\n') {
-      row.push(field);
-      rows.push(row);
-      row = [];
-      field = '';
-    } else if (c !== '\r') {
-      field += c;
-    }
-  }
-  if (field.length > 0 || row.length > 0) {
-    row.push(field);
-    rows.push(row);
-  }
-  return { rows, unterminatedQuote: inQuotes };
-}
+/** Minimal RFC-4180-ish delimited parser: shared in scripts/lib/delimited.ts. */
 
 function findInputFile(): string | null {
   const isFlag = (a: string) => a.startsWith('--') || a === '-n';
@@ -207,8 +167,6 @@ if (table.length === 0) {
 
 // The header is the first non-blank, non-comment row (the list may open
 // with "#" comment lines). Row loop below starts after it.
-const isBlankOrComment = (cells: string[]) =>
-  cells.every((c) => c.trim() === '') || (cells[0] ?? '').trim().startsWith('#');
 const headerIdx = table.findIndex((cells) => !isBlankOrComment(cells));
 if (headerIdx === -1) {
   console.error(`❌ ${inputFile} has no header row (expected columns: ${[...REQUIRED_COLUMNS, 'description'].join(', ')}).`);

--- a/scripts/lib/delimited.ts
+++ b/scripts/lib/delimited.ts
@@ -1,0 +1,51 @@
+/**
+ * Minimal RFC-4180-ish delimited (CSV/TSV) parser shared by the deterministic
+ * content generators (bulk-new-posts, sync-codes). Quoted fields, "" escapes;
+ * auto-detects tab vs comma from the first line. Reports an unterminated
+ * quote instead of silently swallowing the file tail.
+ */
+export function parseDelimited(text: string): { rows: string[][]; unterminatedQuote: boolean } {
+  const firstLine = text.slice(0, text.indexOf('\n') === -1 ? text.length : text.indexOf('\n'));
+  const delim = firstLine.includes('\t') && !firstLine.includes(',') ? '\t' : ',';
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = '';
+  let inQuotes = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (inQuotes) {
+      if (c === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += c;
+      }
+    } else if (c === '"') {
+      inQuotes = true;
+    } else if (c === delim) {
+      row.push(field);
+      field = '';
+    } else if (c === '\n') {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = '';
+    } else if (c !== '\r') {
+      field += c;
+    }
+  }
+  if (field.length > 0 || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+  return { rows, unterminatedQuote: inQuotes };
+}
+
+/** The first row that is neither blank nor starts with "#" — the header. */
+export function isBlankOrComment(cells: string[]): boolean {
+  return cells.every((c) => c.trim() === '') || (cells[0] ?? '').trim().startsWith('#');
+}

--- a/scripts/lib/sync-codes.ts
+++ b/scripts/lib/sync-codes.ts
@@ -140,6 +140,18 @@ export function parseCodesCsv(text: string, locales: readonly string[]): CsvResu
       continue;
     }
 
+    // A newline/control char inside a cell would be written into a single-
+    // quoted YAML scalar literally, producing INVALID frontmatter that only
+    // `pnpm build` would catch — far too late. Reject loudly at parse time.
+    let hasControlError = false;
+    for (const [name, value] of [['code', code], ['reward', get('reward')], ['expiryDate', expiryDate], ['source', get('source')]] as const) {
+      if (/[\n\r\u0000-\u0008\u000B-\u001F\u007F]/.test(value)) {
+        result.errors.push(`line ${line}: "${name}" contains a newline/control character (not valid in a YAML scalar)`);
+        hasControlError = true;
+      }
+    }
+    if (hasControlError) continue;
+
     const dedupeKey = `${locale}/${slug}/${code}`;
     if (seen.has(dedupeKey)) {
       result.errors.push(`line ${line}: duplicate row for ${locale}/${slug} code "${code}"`);
@@ -201,6 +213,47 @@ export function mergeCodes(
     }
   }
   return { merged: [...addedEntries, ...existing], stats };
+}
+
+// ---------------------------------------------------------------------------
+// Cross-locale fan-out
+// ---------------------------------------------------------------------------
+
+/** Expand per-locale rows to every locale that has the same slug page but no
+ * explicit row — the anvil-update-codes skill's Step 3 semantics ("同步数据"
+ * wherever a same-name page exists). Explicit rows always win (so per-locale
+ * translated reward/source text stays possible); fan-out rows are shallow
+ * clones of the slug's FIRST explicit row with only the locale changed, i.e.
+ * reward/source text is copied as-given and needs a wording review on non-en
+ * locales. Only `targetLocales` are filled (respects the --locales filter);
+ * locales without an existing page are skipped (sync never creates pages). */
+export function fanOutLocales(
+  groups: Map<string, CodesCsvRow[]>,
+  targetLocales: readonly string[],
+  hasPage: (locale: string, slug: string) => boolean,
+): { groups: Map<string, CodesCsvRow[]>; notes: string[] } {
+  const notes: string[] = [];
+  const expanded = new Map(groups);
+  const covered = new Map<string, Set<string>>(); // slug → locales with rows
+  const sources = new Map<string, CodesCsvRow>(); // slug → first explicit row
+  for (const [key, rows] of groups) {
+    const [locale, slug] = key.split('/');
+    if (!covered.has(slug)) covered.set(slug, new Set());
+    covered.get(slug)!.add(locale);
+    if (!sources.has(slug)) sources.set(slug, rows[0]);
+  }
+  for (const [slug, source] of sources) {
+    for (const locale of targetLocales) {
+      if (covered.get(slug)!.has(locale)) continue;
+      if (!hasPage(locale, slug)) continue;
+      expanded.set(`${locale}/${slug}`, [{ ...source, locale, line: source.line }]);
+      covered.get(slug)!.add(locale);
+      notes.push(
+        `slug "${slug}": locale "${locale}" has no CSV row → synced from the "${source.locale}" row (line ${source.line}); review reward/source wording`,
+      );
+    }
+  }
+  return { groups: expanded, notes };
 }
 
 // ---------------------------------------------------------------------------
@@ -267,11 +320,20 @@ function readScalar(raw: string, lineNo: number): { value: string } | { error: s
   return { value: scanned.value };
 }
 
+/** A CRLF-saved page (Windows editors are an explicit supported audience)
+ * must sync like any other: parse on a normalized copy, and remember the
+ * file's EOL so upsert can re-apply it instead of silently converting. */
+function splitLines(fileText: string): { lines: string[]; eol: string } {
+  const eol = fileText.includes('\r\n') ? '\r\n' : '\n';
+  const lines = (eol === '\r\n' ? fileText.replace(/\r\n/g, '\n') : fileText).split('\n');
+  return { lines, eol };
+}
+
 /** Parse the `codes:` frontmatter block. Conservative: any structure beyond
  * flat single-line scalars (nested maps, multiline strings, unknown keys,
  * comments inside the block) is a loud error, never a silent rewrite. */
 export function parseCodesBlock(fileText: string): ParsedCodes | { error: string } {
-  const lines = fileText.split('\n');
+  const { lines } = splitLines(fileText);
   if ((lines[0] ?? '').trim() !== '---') return { error: 'file does not start with a frontmatter --- delimiter' };
   let closing = -1;
   for (let i = 1; i < lines.length; i++) {
@@ -368,13 +430,14 @@ export function serializeCodesBlock(entries: CodesEntry[]): string[] {
 }
 
 /** Replace (or insert) the codes block and bump lastModified. Everything
- * outside the touched lines is preserved byte-for-byte. */
+ * outside the touched lines is preserved byte-for-byte; the file's original
+ * EOL style (LF or CRLF) is kept. */
 export function upsertCodesFrontmatter(
   fileText: string,
   entries: CodesEntry[],
   today: string,
 ): { output: string } | { error: string } {
-  const lines = fileText.split('\n');
+  const { lines, eol } = splitLines(fileText);
   if ((lines[0] ?? '').trim() !== '---') return { error: 'file does not start with a frontmatter --- delimiter' };
   let closing = -1;
   for (let i = 1; i < lines.length; i++) {
@@ -423,5 +486,5 @@ export function upsertCodesFrontmatter(
   } else {
     lines.splice(closing, 0, ...block);
   }
-  return { output: lines.join('\n') };
+  return { output: lines.join(eol) };
 }

--- a/scripts/lib/sync-codes.ts
+++ b/scripts/lib/sync-codes.ts
@@ -1,0 +1,427 @@
+/**
+ * sync-codes.ts — pure functions behind `pnpm sync-codes` (scripts/sync-codes.ts).
+ *
+ * Deterministic batch updater for the structured `codes:` frontmatter array on
+ * codes pages: a CSV of (locale, slug, code, status, …) rows is merged into
+ * existing MDX frontmatter. It is the mechanical half of the anvil-update-codes
+ * skill and never invents or deletes a code:
+ *   - new codes are PREPENDED (newest first, mirroring the skill)
+ *   - flipping to expired keeps the entry (long-tail "is X still working" SEO)
+ *   - empty optional CSV cells keep the existing frontmatter value
+ *
+ * Everything here is pure (string in → string out) so vitest can pin the YAML
+ * serialization byte-for-byte; the CLI only adds fs + argv. Frontmatter
+ * handling is deliberately conservative: anything the flat-scalar parser
+ * cannot understand aborts the file loudly instead of rewriting blind.
+ */
+
+import { isBlankOrComment, parseDelimited } from './delimited';
+
+export type CodeStatus = 'active' | 'expired';
+
+export interface CodesEntry {
+  code: string;
+  reward?: string;
+  status: CodeStatus;
+  expiryDate?: string;
+  source?: string;
+}
+
+export interface CodesCsvRow {
+  line: number; // 1-based CSV line, for error messages
+  locale: string;
+  slug: string;
+  code: string;
+  status: CodeStatus;
+  reward: string; // '' = not provided
+  expiryDate: string; // '' = not provided
+  source: string; // '' = not provided
+}
+
+export interface CsvResult {
+  rows: CodesCsvRow[];
+  errors: string[];
+  notes: string[];
+}
+
+export interface MergeStats {
+  added: string[];
+  updated: string[];
+  expiredFlipped: string[];
+  unchanged: string[];
+}
+
+const CODE_STATUSES: readonly CodeStatus[] = ['active', 'expired'];
+const KNOWN_ENTRY_KEYS = ['code', 'reward', 'status', 'expiryDate', 'source'];
+const CSV_COLUMNS = ['locale', 'slug', 'code', 'status', 'reward', 'expiryDate', 'source'];
+const REQUIRED_COLUMNS = ['slug', 'code'] as const;
+
+// ---------------------------------------------------------------------------
+// CSV
+// ---------------------------------------------------------------------------
+
+/** Parse and validate a codes-sync CSV/TSV. All-or-nothing: hard errors
+ * surface in `errors` and the caller must not write anything. */
+export function parseCodesCsv(text: string, locales: readonly string[]): CsvResult {
+  const { rows: table, unterminatedQuote } = parseDelimited(text);
+  const result: CsvResult = { rows: [], errors: [], notes: [] };
+  if (unterminatedQuote) {
+    result.errors.push('input has an unterminated quoted field — a " opened but never closed');
+    return result;
+  }
+  if (table.length === 0) {
+    result.errors.push('input is empty');
+    return result;
+  }
+
+  const headerIdx = table.findIndex((cells) => !isBlankOrComment(cells));
+  if (headerIdx === -1) {
+    result.errors.push(`no header row found (expected columns: ${CSV_COLUMNS.join(', ')})`);
+    return result;
+  }
+  const header = table[headerIdx].map((h) => h.trim().toLowerCase());
+  // Column names are camelCase (expiryDate) but the header is matched
+  // case-insensitively so "expirydate" in the CSV works too.
+  const colIndex = (name: string) => header.indexOf(name.toLowerCase());
+  for (const col of REQUIRED_COLUMNS) {
+    if (colIndex(col) === -1) {
+      result.errors.push(`header is missing the "${col}" column (found: ${header.join(', ')})`);
+    }
+  }
+  if (result.errors.length > 0) return result;
+
+  const seen = new Set<string>(); // locale/slug/code → dedupe
+  for (let r = headerIdx + 1; r < table.length; r++) {
+    const cells = table[r];
+    if (isBlankOrComment(cells)) continue;
+    const line = r + 1;
+    const get = (name: string) => (cells[colIndex(name)] ?? '').trim();
+
+    let locale = get('locale');
+    if (!locale) {
+      locale = 'en';
+      result.notes.push(`line ${line}: empty locale → defaulted to "en"`);
+    }
+    if (!locales.includes(locale)) {
+      result.errors.push(`line ${line}: locale "${locale}" is not in routing.ts (${locales.join(', ')})`);
+      continue;
+    }
+
+    const slug = get('slug');
+    if (!slug) {
+      result.errors.push(`line ${line}: slug is empty`);
+      continue;
+    }
+    if (slug !== slug.toLowerCase()) {
+      result.notes.push(`line ${line}: slug "${slug}" — target file must exist as-is; slugs are case-sensitive`);
+    }
+
+    const code = get('code');
+    if (!code) {
+      result.errors.push(`line ${line}: code is empty`);
+      continue;
+    }
+
+    const statusRaw = get('status').toLowerCase();
+    let status: CodeStatus = 'active';
+    if (statusRaw && !CODE_STATUSES.includes(statusRaw as CodeStatus)) {
+      result.errors.push(`line ${line}: status "${statusRaw}" is not active|expired`);
+      continue;
+    }
+    if (!statusRaw) {
+      status = 'active';
+    } else {
+      status = statusRaw as CodeStatus;
+    }
+
+    const expiryDate = get('expiryDate');
+    if (expiryDate.length > 40) {
+      result.errors.push(`line ${line}: expiryDate is ${expiryDate.length} chars (schema max 40)`);
+      continue;
+    }
+
+    const dedupeKey = `${locale}/${slug}/${code}`;
+    if (seen.has(dedupeKey)) {
+      result.errors.push(`line ${line}: duplicate row for ${locale}/${slug} code "${code}"`);
+      continue;
+    }
+    seen.add(dedupeKey);
+
+    result.rows.push({
+      line,
+      locale,
+      slug,
+      code,
+      status,
+      reward: get('reward'),
+      expiryDate,
+      source: get('source'),
+    });
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Merge (never deletes; new codes prepended)
+// ---------------------------------------------------------------------------
+
+export function mergeCodes(
+  existing: CodesEntry[],
+  rows: CodesCsvRow[],
+): { merged: CodesEntry[]; stats: MergeStats } {
+  const stats: MergeStats = { added: [], updated: [], expiredFlipped: [], unchanged: [] };
+  const byCode = new Map<string, CodesEntry>();
+  for (const entry of existing) byCode.set(entry.code, entry);
+
+  const addedEntries: CodesEntry[] = [];
+  for (const row of rows) {
+    const current = byCode.get(row.code);
+    if (!current) {
+      const entry: CodesEntry = { code: row.code, status: row.status };
+      if (row.reward) entry.reward = row.reward;
+      if (row.expiryDate) entry.expiryDate = row.expiryDate;
+      if (row.source) entry.source = row.source;
+      addedEntries.push(entry);
+      byCode.set(row.code, entry);
+      stats.added.push(row.code);
+      continue;
+    }
+    const before = JSON.stringify(current);
+    const statusBefore = current.status;
+    current.status = row.status;
+    if (row.reward) current.reward = row.reward;
+    if (row.expiryDate) current.expiryDate = row.expiryDate;
+    if (row.source) current.source = row.source;
+    if (JSON.stringify(current) === before) {
+      stats.unchanged.push(row.code);
+    } else if (statusBefore === 'active' && row.status === 'expired') {
+      stats.expiredFlipped.push(row.code);
+    } else {
+      stats.updated.push(row.code);
+    }
+  }
+  return { merged: [...addedEntries, ...existing], stats };
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter: parse the flat codes block
+// ---------------------------------------------------------------------------
+
+export interface ParsedCodes {
+  codes: CodesEntry[];
+  hasBlock: boolean; // an explicit `codes:` key exists (vs no key at all)
+}
+
+/** Scan one YAML scalar: returns its value plus any trailing content after a
+ * properly closed quote (comments/garbage — which the caller must reject,
+ * since an inline comment would be silently corrupted on rewrite). */
+function scanYamlScalar(raw: string): { value: string; rest: string } | { error: string } {
+  const v = raw.trim();
+  if (v.startsWith("'")) {
+    let i = 1;
+    let out = '';
+    while (i < v.length) {
+      if (v[i] === "'") {
+        if (v[i + 1] === "'") {
+          out += "'";
+          i += 2;
+          continue;
+        }
+        break;
+      }
+      out += v[i];
+      i++;
+    }
+    if (i >= v.length) return { error: 'unterminated single-quoted value' };
+    return { value: out, rest: v.slice(i + 1) };
+  }
+  if (v.startsWith('"')) {
+    let i = 1;
+    let out = '';
+    while (i < v.length) {
+      if (v[i] === '\\') {
+        out += v[i + 1] ?? '';
+        i += 2;
+        continue;
+      }
+      if (v[i] === '"') break;
+      out += v[i];
+      i++;
+    }
+    if (i >= v.length) return { error: 'unterminated double-quoted value' };
+    return { value: out, rest: v.slice(i + 1) };
+  }
+  return { value: v, rest: '' };
+}
+
+/** Read a scalar and reject inline comments / trailing garbage. */
+function readScalar(raw: string, lineNo: number): { value: string } | { error: string } {
+  const scanned = scanYamlScalar(raw);
+  if ('error' in scanned) return { error: `line ${lineNo}: ${scanned.error}` };
+  if (scanned.rest.trim() !== '') {
+    return { error: `line ${lineNo}: inline comments/trailing content are not supported in the codes block ("${raw.trim().slice(0, 40)}")` };
+  }
+  if (!raw.trim().startsWith("'") && !raw.trim().startsWith('"') && scanned.value.includes('#')) {
+    return { error: `line ${lineNo}: inline comments are not supported in the codes block` };
+  }
+  return { value: scanned.value };
+}
+
+/** Parse the `codes:` frontmatter block. Conservative: any structure beyond
+ * flat single-line scalars (nested maps, multiline strings, unknown keys,
+ * comments inside the block) is a loud error, never a silent rewrite. */
+export function parseCodesBlock(fileText: string): ParsedCodes | { error: string } {
+  const lines = fileText.split('\n');
+  if ((lines[0] ?? '').trim() !== '---') return { error: 'file does not start with a frontmatter --- delimiter' };
+  let closing = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') {
+      closing = i;
+      break;
+    }
+  }
+  if (closing === -1) return { error: 'frontmatter is not closed (no second ---)' };
+
+  let codesLine = -1;
+  for (let i = 1; i < closing; i++) {
+    const m = lines[i].match(/^codes:\s*(.*)$/);
+    if (m) {
+      codesLine = i;
+      if (m[1].trim() && m[1].trim() !== '[]') {
+        return { error: `codes: has inline value "${m[1].trim()}" — only a block list or [] is supported` };
+      }
+      break;
+    }
+  }
+  if (codesLine === -1) return { codes: [], hasBlock: false };
+
+  // Block extends until the first non-blank, non-indented line.
+  let end = closing;
+  for (let i = codesLine + 1; i < closing; i++) {
+    const l = lines[i];
+    if (l.trim() === '') continue;
+    if (/^\s/.test(l)) continue;
+    end = i;
+    break;
+  }
+
+  const codes: CodesEntry[] = [];
+  let current: CodesEntry | null = null;
+  for (let i = codesLine + 1; i < end; i++) {
+    const l = lines[i];
+    if (l.trim() === '') continue;
+    const entryStart = l.match(/^\s*-\s+code:\s*(.*)$/);
+    if (entryStart) {
+      const codeRead = readScalar(entryStart[1], i + 1);
+      if ('error' in codeRead) return codeRead;
+      if (current) codes.push(current);
+      if (!codeRead.value) return { error: `line ${i + 1}: codes entry has an empty code` };
+      current = { code: codeRead.value, status: 'active' };
+      continue;
+    }
+    const field = l.match(/^\s+([A-Za-z][A-Za-z0-9_-]*):\s*(.*)$/);
+    if (field && current) {
+      const key = field[1];
+      if (!KNOWN_ENTRY_KEYS.includes(key)) {
+        return { error: `line ${i + 1}: unknown key "${key}" in codes entry (supported: ${KNOWN_ENTRY_KEYS.join(', ')})` };
+      }
+      if (key === 'code') return { error: `line ${i + 1}: "code" must start its entry ("- code: …")` };
+      const valueRead = readScalar(field[2], i + 1);
+      if ('error' in valueRead) return valueRead;
+      const value = valueRead.value;
+      if (key === 'status') {
+        if (value !== 'active' && value !== 'expired') {
+          return { error: `line ${i + 1}: status "${value}" is not active|expired` };
+        }
+        current.status = value;
+      } else if (value) {
+        if (key === 'reward') current.reward = value;
+        else if (key === 'expiryDate') current.expiryDate = value;
+        else if (key === 'source') current.source = value;
+      }
+      continue;
+    }
+    return { error: `line ${i + 1}: unrecognised line in codes block ("${l.trim().slice(0, 60)}") — manual review needed` };
+  }
+  if (current) codes.push(current);
+  return { codes, hasBlock: true };
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter: serialize + splice back
+// ---------------------------------------------------------------------------
+
+const quoteYaml = (v: string) => `'${v.replace(/'/g, "''")}'`;
+const BARE_CODE = /^[A-Za-z0-9][A-Za-z0-9_.-]*$/;
+
+export function serializeCodesBlock(entries: CodesEntry[]): string[] {
+  const lines: string[] = ['codes:'];
+  for (const e of entries) {
+    // Key order mirrors the demo page convention: code, reward, status, …
+    lines.push(`  - code: ${BARE_CODE.test(e.code) ? e.code : quoteYaml(e.code)}`);
+    if (e.reward) lines.push(`    reward: ${quoteYaml(e.reward)}`);
+    lines.push(`    status: ${e.status}`);
+    if (e.expiryDate) lines.push(`    expiryDate: ${quoteYaml(e.expiryDate)}`);
+    if (e.source) lines.push(`    source: ${quoteYaml(e.source)}`);
+  }
+  return lines;
+}
+
+/** Replace (or insert) the codes block and bump lastModified. Everything
+ * outside the touched lines is preserved byte-for-byte. */
+export function upsertCodesFrontmatter(
+  fileText: string,
+  entries: CodesEntry[],
+  today: string,
+): { output: string } | { error: string } {
+  const lines = fileText.split('\n');
+  if ((lines[0] ?? '').trim() !== '---') return { error: 'file does not start with a frontmatter --- delimiter' };
+  let closing = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') {
+      closing = i;
+      break;
+    }
+  }
+  if (closing === -1) return { error: 'frontmatter is not closed (no second ---)' };
+
+  // 1) lastModified: replace in place, or insert after `date:` / before close.
+  let lastModified = -1;
+  let dateLine = -1;
+  for (let i = 1; i < closing; i++) {
+    if (/^lastModified:/.test(lines[i])) lastModified = i;
+    if (/^date:/.test(lines[i])) dateLine = i;
+  }
+  if (lastModified !== -1) {
+    lines[lastModified] = `lastModified: ${today}`;
+  } else if (dateLine !== -1) {
+    lines.splice(dateLine + 1, 0, `lastModified: ${today}`);
+    closing += 1;
+  } else {
+    lines.splice(closing, 0, `lastModified: ${today}`);
+    closing += 1;
+  }
+
+  // 2) codes block: replace existing lines, or insert before the closing ---.
+  const block = serializeCodesBlock(entries);
+  let codesLine = -1;
+  for (let i = 1; i < closing; i++) {
+    if (/^codes:/.test(lines[i])) {
+      codesLine = i;
+      break;
+    }
+  }
+  if (codesLine !== -1) {
+    let end = closing;
+    for (let i = codesLine + 1; i < closing; i++) {
+      if (lines[i].trim() === '') continue;
+      if (/^\s/.test(lines[i])) continue;
+      end = i;
+      break;
+    }
+    lines.splice(codesLine, end - codesLine, ...block);
+  } else {
+    lines.splice(closing, 0, ...block);
+  }
+  return { output: lines.join('\n') };
+}

--- a/scripts/sync-codes.ts
+++ b/scripts/sync-codes.ts
@@ -1,0 +1,230 @@
+/**
+ * sync-codes.ts
+ *
+ * Deterministic batch updater for codes pages: read a CSV of redeem-code rows
+ * and merge them into the structured `codes:` frontmatter array of existing
+ * MDX pages under src/content/wiki/<locale>/codes/<slug>.mdx — the mechanical
+ * half of the anvil-update-codes skill (see docs/content-pipeline.md).
+ *
+ * Input columns (header row required, order free, case-insensitive):
+ *   locale,slug,code[,status][,reward][,expiryDate][,source]
+ *   - locale empty → defaults to "en"; status empty → "active"
+ *   - the same slug in every available locale is updated together (codes are
+ *     not translated); reward/source text is copied as-given — review
+ *     translations on non-en locales afterwards
+ *   - lines starting with "#" are comments; blank lines are skipped
+ *
+ * Merge rules (never invents, never deletes):
+ *   - a code not yet on the page is PREPENDED (newest first)
+ *   - status expired flips the existing entry and KEEPS it (long-tail SEO)
+ *   - empty optional CSV cells keep the existing frontmatter value
+ *
+ * Target pages must already exist — sync never creates pages (use
+ * pnpm new-post / anvil-new-article for that). Every file is parsed and
+ * validated BEFORE anything is written (all-or-nothing); a codes block the
+ * flat-scalar parser cannot understand aborts loudly instead of rewriting.
+ *
+ * Usage:
+ *   pnpm sync-codes                  # reads codes-sync.csv / codes-sync.tsv at repo root
+ *   pnpm sync-codes my-codes.csv     # explicit file
+ *   pnpm sync-codes --dry-run        # print the plan, write nothing
+ *   pnpm sync-codes --locales=en,ja  # only apply rows for these locales
+ *
+ * Style matches scripts/bulk-new-posts.ts (node builtins, emoji output).
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  mergeCodes,
+  parseCodesBlock,
+  parseCodesCsv,
+  upsertCodesFrontmatter,
+  type CodesCsvRow,
+  type MergeStats,
+} from './lib/sync-codes';
+
+const ROOT = process.cwd();
+const CONTENT_BASE = path.resolve(ROOT, 'src/content/wiki');
+const ARGS = process.argv.slice(2);
+const DRY_RUN = ARGS.includes('--dry-run') || ARGS.includes('-n');
+
+const LOCALES_FLAG = ARGS.find((a) => a.startsWith('--locales'));
+const LOCALE_FILTER = LOCALES_FLAG ? LOCALES_FLAG.split('=')[1]?.split(',').map((s) => s.trim()).filter(Boolean) : null;
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+// Same config-reading helper as bulk-new-posts.ts (regex-read, no imports).
+function readLocales(): string[] {
+  const src = fs.readFileSync(path.resolve(ROOT, 'src/i18n/routing.ts'), 'utf8');
+  const match = src.match(/locales\s*=\s*\[([^\]]+)\]/);
+  if (!match) {
+    console.error('❌ Could not parse locales from src/i18n/routing.ts (expected `locales = [\'…\']`).');
+    process.exit(1);
+  }
+  return Array.from(match[1].matchAll(/['"]([^'"]+)['"]/g)).map((m) => m[1]);
+}
+
+function findInputFile(): string | null {
+  const isFlag = (a: string) => a.startsWith('--') || a === '-n';
+  const argFile = ARGS.find((a) => !isFlag(a));
+  if (argFile) {
+    const abs = path.resolve(ROOT, argFile);
+    if (!fs.existsSync(abs) || !fs.statSync(abs).isFile()) {
+      console.error(`❌ Input file not found: ${argFile}`);
+      return null;
+    }
+    return argFile;
+  }
+  for (const candidate of ['codes-sync.csv', 'codes-sync.tsv']) {
+    const abs = path.resolve(ROOT, candidate);
+    if (fs.existsSync(abs) && fs.statSync(abs).isFile()) return candidate;
+  }
+  return null;
+}
+
+const NO_INPUT_IS_ERROR = ARGS.some((a) => !a.startsWith('--') && a !== '-n');
+
+const inputFile = findInputFile();
+if (!inputFile) {
+  console.log(`
+🔁 AnvilWiki codes sync
+
+No list file found (looked for codes-sync.csv / codes-sync.tsv at the repo root).
+Create one, or pass a path explicitly.
+
+Usage:
+  pnpm sync-codes                  reads codes-sync.csv (or .tsv) at the repo root
+  pnpm sync-codes <file>           explicit list file
+  pnpm sync-codes --dry-run        preview the plan, write nothing
+  pnpm sync-codes --locales=en,ja  only apply rows for these locales
+
+Expected file (header required, order free; status/reward/expiryDate/source optional):
+
+  locale,slug,code,status,reward,expiryDate,source
+  en,all-codes,SUMMER-2026,active,"+500 Gold",Sep 30,Official Discord
+  en,all-codes,FROSTPIKE,expired
+
+Rules: new codes are prepended; expired flips keep the entry; empty optional
+cells keep the existing values; codes data is synced to every locale that has
+the same page. Pages must already exist — sync never creates or deletes.`);
+  process.exit(NO_INPUT_IS_ERROR ? 1 : 0);
+}
+
+if (LOCALE_FILTER) {
+  const locales = readLocales();
+  const unknown = LOCALE_FILTER.filter((l) => !locales.includes(l));
+  if (unknown.length > 0) {
+    console.error(`❌ --locales: unknown locale(s) ${unknown.join(', ')} (routing.ts has: ${locales.join(', ')})`);
+    process.exit(1);
+  }
+}
+
+const locales = readLocales();
+const raw = fs.readFileSync(path.resolve(ROOT, inputFile), 'utf8');
+const { rows, errors, notes } = parseCodesCsv(raw, locales);
+
+const filtered = LOCALE_FILTER
+  ? rows.filter((r) => {
+      if (LOCALE_FILTER.includes(r.locale)) return true;
+      notes.push(`line ${r.line}: locale "${r.locale}" skipped (--locales filter)`);
+      return false;
+    })
+  : rows;
+
+// Group by target page, preserving first-appearance order.
+const groups = new Map<string, CodesCsvRow[]>();
+for (const row of filtered) {
+  const key = `${row.locale}/${row.slug}`;
+  const list = groups.get(key);
+  if (list) list.push(row);
+  else groups.set(key, [row]);
+}
+
+console.log(`\n🔁 AnvilWiki — codes sync (${inputFile})\n`);
+for (const note of notes) console.log(`  ℹ️  ${note}`);
+
+if (errors.length > 0) {
+  console.error(`\n❌ ${errors.length} invalid row${errors.length === 1 ? '' : 's'} — nothing written (fix the list and re-run):\n`);
+  for (const e of errors) console.error(`  ❌ ${e}`);
+  process.exit(1);
+}
+if (filtered.length === 0) {
+  console.log('\nNothing to do (no rows after filtering).');
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Parse + merge every target file BEFORE writing anything (all-or-nothing)
+// ---------------------------------------------------------------------------
+interface Planned {
+  filePath: string;
+  label: string;
+  output: string;
+  stats: MergeStats;
+}
+
+const planned: Planned[] = [];
+const fileErrors: string[] = [];
+for (const [key, group] of groups) {
+  const label = `src/content/wiki/${key.replace('/', '/codes/')}.mdx`;
+  const filePath = path.join(CONTENT_BASE, key.split('/')[0], 'codes', `${key.split('/')[1]}.mdx`);
+  if (!fs.existsSync(filePath)) {
+    fileErrors.push(`${label} — target page does not exist (sync never creates pages; create it first)`);
+    continue;
+  }
+  const fileText = fs.readFileSync(filePath, 'utf8');
+  const parsed = parseCodesBlock(fileText);
+  if ('error' in parsed) {
+    fileErrors.push(`${label} — ${parsed.error}`);
+    continue;
+  }
+  const { merged, stats } = mergeCodes(parsed.codes, group);
+  const upserted = upsertCodesFrontmatter(fileText, merged, todayIso());
+  if ('error' in upserted) {
+    fileErrors.push(`${label} — ${upserted.error}`);
+    continue;
+  }
+  planned.push({ filePath, label, output: upserted.output, stats });
+}
+
+if (fileErrors.length > 0) {
+  console.error(`\n❌ ${fileErrors.length} file${fileErrors.length === 1 ? '' : 's'} cannot be synced — nothing written:\n`);
+  for (const e of fileErrors) console.error(`  ❌ ${e}`);
+  process.exit(1);
+}
+
+const describeStats = (s: MergeStats): string => {
+  const parts: string[] = [];
+  if (s.added.length > 0) parts.push(`＋ ${s.added.length} new (${s.added.join(', ')})`);
+  if (s.expiredFlipped.length > 0) parts.push(`💀 ${s.expiredFlipped.length} expired (${s.expiredFlipped.join(', ')})`);
+  if (s.updated.length > 0) parts.push(`⟳ ${s.updated.length} updated (${s.updated.join(', ')})`);
+  if (s.unchanged.length > 0) parts.push(`= ${s.unchanged.length} unchanged`);
+  return parts.length > 0 ? parts.join(' · ') : 'no changes';
+};
+
+if (DRY_RUN) {
+  console.log('\n🔍 Dry run — nothing written. Plan:\n');
+  for (const p of planned) {
+    console.log(`  ${p.label}\n    ${describeStats(p.stats)}`);
+  }
+  console.log('\nRe-run without --dry-run to write.');
+  process.exit(0);
+}
+
+let touched = 0;
+for (const p of planned) {
+  fs.writeFileSync(p.filePath, p.output, 'utf8');
+  touched += 1;
+  console.log(`  ✅ ${p.label}`);
+  console.log(`     ${describeStats(p.stats)}`);
+}
+
+console.log(
+  `\n📊 Synced ${touched} page${touched === 1 ? '' : 's'}, lastModified → ${todayIso()}. Next:` +
+    `\n   1. Review reward/source wording on non-en locales (sync copies text as-given)` +
+    `\n   2. Verify: pnpm check-content && pnpm build` +
+    `\n   3. Commit the pages (one commit per game keeps history reviewable).`,
+);

--- a/scripts/sync-codes.ts
+++ b/scripts/sync-codes.ts
@@ -36,6 +36,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {
+  fanOutLocales,
   mergeCodes,
   parseCodesBlock,
   parseCodesCsv,
@@ -49,8 +50,24 @@ const CONTENT_BASE = path.resolve(ROOT, 'src/content/wiki');
 const ARGS = process.argv.slice(2);
 const DRY_RUN = ARGS.includes('--dry-run') || ARGS.includes('-n');
 
+// Unknown flags are rejected loudly: a typo'd --drry-run must fail, never
+// silently degrade into a real write.
+const UNKNOWN_FLAGS = ARGS.filter((a) => a.startsWith('-') && a !== '-n' && a !== '--dry-run' && !a.startsWith('--locales'));
+if (UNKNOWN_FLAGS.length > 0) {
+  console.error(`❌ Unknown flag(s): ${UNKNOWN_FLAGS.join(', ')} — supported: --dry-run/-n, --locales=<comma,list>`);
+  process.exit(1);
+}
+
 const LOCALES_FLAG = ARGS.find((a) => a.startsWith('--locales'));
-const LOCALE_FILTER = LOCALES_FLAG ? LOCALES_FLAG.split('=')[1]?.split(',').map((s) => s.trim()).filter(Boolean) : null;
+const LOCALE_FILTER = (() => {
+  if (!LOCALES_FLAG) return null;
+  const list = LOCALES_FLAG.slice('--locales='.length).split(',').map((s) => s.trim()).filter(Boolean);
+  if (list.length === 0) {
+    console.error('❌ --locales requires a comma-separated locale list, e.g. --locales=en,ja');
+    process.exit(1);
+  }
+  return list;
+})();
 
 function todayIso(): string {
   return new Date().toISOString().slice(0, 10);
@@ -156,6 +173,15 @@ if (filtered.length === 0) {
   process.exit(0);
 }
 
+// Cross-locale fan-out: a slug with no row for an existing page's locale
+// follows the slug's first explicit row (skill Step 3 semantics). Explicit
+// rows win; fan-out only fills locales that pass the --locales filter.
+const fanTargets = LOCALE_FILTER ?? locales;
+const fan = fanOutLocales(groups, fanTargets, (locale, slug) =>
+  fs.existsSync(path.join(CONTENT_BASE, locale, 'codes', `${slug}.mdx`)),
+);
+for (const note of fan.notes) console.log(`  ℹ️  ${note}`);
+
 // ---------------------------------------------------------------------------
 // Parse + merge every target file BEFORE writing anything (all-or-nothing)
 // ---------------------------------------------------------------------------
@@ -168,7 +194,7 @@ interface Planned {
 
 const planned: Planned[] = [];
 const fileErrors: string[] = [];
-for (const [key, group] of groups) {
+for (const [key, group] of fan.groups) {
   const label = `src/content/wiki/${key.replace('/', '/codes/')}.mdx`;
   const filePath = path.join(CONTENT_BASE, key.split('/')[0], 'codes', `${key.split('/')[1]}.mdx`);
   if (!fs.existsSync(filePath)) {
@@ -205,17 +231,30 @@ const describeStats = (s: MergeStats): string => {
   return parts.length > 0 ? parts.join(' · ') : 'no changes';
 };
 
+const hasChanges = (s: MergeStats): boolean => s.added.length + s.updated.length + s.expiredFlipped.length > 0;
+
 if (DRY_RUN) {
   console.log('\n🔍 Dry run — nothing written. Plan:\n');
   for (const p of planned) {
-    console.log(`  ${p.label}\n    ${describeStats(p.stats)}`);
+    const cleanNote = hasChanges(p.stats) ? '' : '  (no changes → will not be rewritten)';
+    console.log(`  ${p.label}\n    ${describeStats(p.stats)}${cleanNote}`);
   }
   console.log('\nRe-run without --dry-run to write.');
   process.exit(0);
 }
 
 let touched = 0;
+let skippedClean = 0;
 for (const p of planned) {
+  // A page whose rows are all "unchanged" is not rewritten: lastModified is a
+  // freshness signal (refresh-audit reads it) — never bump it without a real
+  // change to show for it.
+  if (!hasChanges(p.stats)) {
+    console.log(`  ⏭️  ${p.label}`);
+    console.log('     no changes — not rewritten (lastModified preserved)');
+    skippedClean += 1;
+    continue;
+  }
   fs.writeFileSync(p.filePath, p.output, 'utf8');
   touched += 1;
   console.log(`  ✅ ${p.label}`);
@@ -223,8 +262,11 @@ for (const p of planned) {
 }
 
 console.log(
-  `\n📊 Synced ${touched} page${touched === 1 ? '' : 's'}, lastModified → ${todayIso()}. Next:` +
-    `\n   1. Review reward/source wording on non-en locales (sync copies text as-given)` +
-    `\n   2. Verify: pnpm check-content && pnpm build` +
-    `\n   3. Commit the pages (one commit per game keeps history reviewable).`,
+  `\n📊 Synced ${touched} page${touched === 1 ? '' : 's'}` +
+    (skippedClean > 0 ? ` (skipped ${skippedClean} unchanged)` : '') +
+    `, lastModified → ${todayIso()} on written pages. Next:` +
+    `\n   1. Update title / summary to match (code count, "as of" date — they feed the Quick Answer card + AI Overviews)` +
+    `\n   2. Review reward/source wording on non-en locales (sync copies text as-given)` +
+    `\n   3. Verify: pnpm check-content && pnpm build` +
+    `\n   4. Commit the pages (one commit per game keeps history reviewable).`,
 );

--- a/tests/sync-codes.test.ts
+++ b/tests/sync-codes.test.ts
@@ -1,0 +1,219 @@
+/**
+ * sync-codes unit tests — the deterministic codes frontmatter updater behind
+ * `pnpm sync-codes` (scripts/sync-codes.ts). The pure functions in
+ * scripts/lib/sync-codes.ts are pinned byte-for-byte: CSV validation must be
+ * all-or-nothing, the merge must never delete codes, and the frontmatter
+ * splice must preserve everything outside the codes block / lastModified.
+ */
+import { describe, expect, test } from 'vitest';
+import {
+  mergeCodes,
+  parseCodesBlock,
+  parseCodesCsv,
+  serializeCodesBlock,
+  upsertCodesFrontmatter,
+  type CodesEntry,
+} from '../scripts/lib/sync-codes';
+
+const LOCALES = ['en', 'ja'];
+
+const pageWithCodes = (codesBlock: string): string => `---
+title: 'All Working Codes (August 2026)'
+description: 'Every working Anvil Quest code in August 2026, tested daily. Redeem for gold, XP boosts, and exclusive cosmetics before they expire.'
+category: 'codes'
+date: 2026-08-14
+lastModified: 2026-08-31
+tags: ['codes', 'redeem']
+summary: 'Summary line.'
+${codesBlock}
+---
+
+## How do I redeem codes?
+
+Body content that must survive the splice byte-for-byte.
+`;
+
+const demoBlock = `codes:
+  - code: FORGE-2026
+    reward: '+500 Gold'
+    status: active
+    expiryDate: 'Aug 31'
+    source: 'Official Discord announcement'
+  - code: FROSTPIKE
+    reward: '+250 Gold'
+    status: expired
+    expiryDate: 'Aug 21'`;
+
+describe('parseCodesCsv', () => {
+  test('parses rows with defaults (locale → en, status → active) and skips comments/blanks', () => {
+    const csv = [
+      '# comment line',
+      '',
+      'locale,slug,code,status,reward,expiryDate,source',
+      'en,all-codes,SUMMER-2026,active,"+500 Gold",Sep 30,Official Discord',
+      'ja,all-codes,SUMMER-2026,,,',
+      ',all-codes,PLAIN,,,',
+    ].join('\n');
+    const { rows, errors, notes } = parseCodesCsv(csv, LOCALES);
+    expect(errors).toEqual([]);
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toMatchObject({ locale: 'en', slug: 'all-codes', code: 'SUMMER-2026', status: 'active', reward: '+500 Gold', expiryDate: 'Sep 30', source: 'Official Discord' });
+    expect(rows[1]).toMatchObject({ locale: 'ja', status: 'active', reward: '', expiryDate: '', source: '' });
+    expect(rows[2]).toMatchObject({ locale: 'en', code: 'PLAIN' });
+    expect(notes.some((n) => n.includes('defaulted to "en"'))).toBe(true);
+  });
+
+  test('rejects unknown locales, bad status, empty code/slug, oversize expiryDate — all-or-nothing', () => {
+    const csv = [
+      'locale,slug,code,status,expiryDate',
+      'fr,all-codes,X,,,', // unknown locale
+      'en,all-codes,Y,sold-out,', // bad status
+      'en,all-codes,,,', // empty code
+      'en,,Z,,', // empty slug
+      `en,all-codes,W,,${'x'.repeat(41)}`, // expiryDate > 40 (schema cap)
+    ].join('\n');
+    const { rows, errors } = parseCodesCsv(csv, LOCALES);
+    expect(rows).toEqual([]);
+    expect(errors).toHaveLength(5);
+  });
+
+  test('rejects duplicate rows for the same page+code and a missing header column', () => {
+    const dup = parseCodesCsv('locale,slug,code\nen,all-codes,A\nen,all-codes,A', LOCALES);
+    expect(dup.errors.some((e) => e.includes('duplicate row'))).toBe(true);
+    const noCol = parseCodesCsv('locale,slug\nen,all-codes', LOCALES);
+    expect(noCol.errors[0]).toContain('missing the "code" column');
+  });
+
+  test('TSV input is auto-detected', () => {
+    const { rows, errors } = parseCodesCsv('locale\tslug\tcode\nen\tall-codes\tTABBY', LOCALES);
+    expect(errors).toEqual([]);
+    expect(rows[0]?.code).toBe('TABBY');
+  });
+});
+
+describe('mergeCodes', () => {
+  const existing: CodesEntry[] = [
+    { code: 'FORGE-2026', reward: '+500 Gold', status: 'active', expiryDate: 'Aug 31' },
+    { code: 'FROSTPIKE', reward: '+250 Gold', status: 'expired', expiryDate: 'Aug 21' },
+  ];
+  const row = (over: Partial<{ code: string; status: 'active' | 'expired'; reward: string; expiryDate: string }>) => ({
+    line: 2,
+    locale: 'en',
+    slug: 'all-codes',
+    code: 'X',
+    status: 'active' as const,
+    reward: '',
+    expiryDate: '',
+    source: '',
+    ...over,
+  });
+
+  test('new codes are prepended in CSV order; existing entries keep their order', () => {
+    const { merged, stats } = mergeCodes(existing, [
+      row({ code: 'NEW-B' }),
+      row({ code: 'NEW-A' }),
+    ]);
+    expect(merged.map((c) => c.code)).toEqual(['NEW-B', 'NEW-A', 'FORGE-2026', 'FROSTPIKE']);
+    expect(stats.added).toEqual(['NEW-B', 'NEW-A']);
+    expect(merged[0]).toMatchObject({ code: 'NEW-B', status: 'active' });
+  });
+
+  test('active → expired flips are tracked and the entry is kept in place', () => {
+    const { merged, stats } = mergeCodes(existing, [row({ code: 'FORGE-2026', status: 'expired' })]);
+    expect(stats.expiredFlipped).toEqual(['FORGE-2026']);
+    const forge = merged.find((c) => c.code === 'FORGE-2026');
+    expect(forge?.status).toBe('expired');
+    expect(merged.map((c) => c.code)).toContain('FORGE-2026');
+  });
+
+  test('empty optional CSV cells keep existing values; provided cells overwrite', () => {
+    const { merged, stats } = mergeCodes(existing, [row({ code: 'FORGE-2026', reward: '+750 Gold' })]);
+    expect(stats.updated).toEqual(['FORGE-2026']);
+    expect(merged[0]).toMatchObject({ reward: '+750 Gold', expiryDate: 'Aug 31' });
+    const again = mergeCodes(merged, [row({ code: 'FORGE-2026', reward: '+750 Gold' })]);
+    expect(again.stats.unchanged).toEqual(['FORGE-2026']);
+  });
+});
+
+describe('parseCodesBlock', () => {
+  test('parses the demo page shape (single quotes, optional fields, bare codes)', () => {
+    const parsed = parseCodesBlock(pageWithCodes(demoBlock));
+    expect('error' in parsed && parsed.error).toBe(false);
+    if ('error' in parsed) return;
+    expect(parsed.hasBlock).toBe(true);
+    expect(parsed.codes).toEqual([
+      { code: 'FORGE-2026', reward: '+500 Gold', status: 'active', expiryDate: 'Aug 31', source: 'Official Discord announcement' },
+      { code: 'FROSTPIKE', reward: '+250 Gold', status: 'expired', expiryDate: 'Aug 21' },
+    ]);
+  });
+
+  test('handles double quotes, unquoted values, codes: [] and a missing block', () => {
+    const mixed = pageWithCodes('codes:\n  - code: "DBL-1"\n    reward: "2× XP (30 min)"\n    status: expired');
+    const parsed = parseCodesBlock(mixed);
+    if ('error' in parsed) throw new Error(parsed.error);
+    expect(parsed.codes[0]).toMatchObject({ code: 'DBL-1', status: 'expired', reward: '2× XP (30 min)' });
+
+    const empty = parseCodesBlock(pageWithCodes('codes: []'));
+    if ('error' in empty) throw new Error(empty.error);
+    expect(empty).toEqual({ codes: [], hasBlock: true });
+
+    const missing = parseCodesBlock('---\ntitle: X\n---\n\nBody.');
+    if ('error' in missing) throw new Error(missing.error);
+    expect(missing).toEqual({ codes: [], hasBlock: false });
+  });
+
+  test('aborts loudly on unknown keys, bad status, inline comments and malformed lines', () => {
+    expect(parseCodesBlock(pageWithCodes('codes:\n  - code: A\n    note: hello'))).toHaveProperty('error');
+    expect(parseCodesBlock(pageWithCodes('codes:\n  - code: A\n    status: maybe'))).toHaveProperty('error');
+    expect(parseCodesBlock(pageWithCodes("codes:\n  - code: A\n    reward: '+5' # note"))).toHaveProperty('error');
+    expect(parseCodesBlock(pageWithCodes('codes:\n  - code: A\n  - - weird'))).toHaveProperty('error');
+    expect(parseCodesBlock('no frontmatter here')).toHaveProperty('error');
+  });
+});
+
+describe('serializeCodesBlock + upsertCodesFrontmatter', () => {
+  test('round-trips the demo block and is idempotent', () => {
+    const page = pageWithCodes(demoBlock);
+    const parsed = parseCodesBlock(page);
+    if ('error' in parsed) throw new Error(parsed.error);
+    const once = upsertCodesFrontmatter(page, parsed.codes, '2026-09-06');
+    if ('error' in once) throw new Error(once.error);
+    const reparsed = parseCodesBlock(once.output);
+    if ('error' in reparsed) throw new Error(reparsed.error);
+    expect(reparsed.codes).toEqual(parsed.codes);
+    const twice = upsertCodesFrontmatter(once.output, reparsed.codes, '2026-09-06');
+    if ('error' in twice) throw new Error(twice.error);
+    expect(twice.output).toBe(once.output);
+  });
+
+  test('bumps lastModified, preserves body and other frontmatter keys', () => {
+    const page = pageWithCodes(demoBlock);
+    const parsed = parseCodesBlock(page);
+    if ('error' in parsed) throw new Error(parsed.error);
+    const out = upsertCodesFrontmatter(page, parsed.codes, '2026-09-06');
+    if ('error' in out) throw new Error(out.error);
+    expect(out.output).toContain('lastModified: 2026-09-06');
+    expect(out.output).toContain("title: 'All Working Codes (August 2026)'");
+    expect(out.output).toContain('Body content that must survive the splice byte-for-byte.');
+    expect(out.output).not.toContain('lastModified: 2026-08-31');
+  });
+
+  test('inserts codes block and lastModified when absent', () => {
+    const page = '---\ntitle: X\ndate: 2026-08-14\ncategory: codes\n---\n\nBody.';
+    const out = upsertCodesFrontmatter(page, [{ code: 'NEW-1', status: 'active', reward: '+1 Gold' }], '2026-09-06');
+    if ('error' in out) throw new Error(out.error);
+    expect(out.output).toContain('lastModified: 2026-09-06');
+    expect(out.output).toMatch(/codes:\n  - code: NEW-1\n    reward: '\+1 Gold'\n    status: active\n---/);
+  });
+
+  test('quotes values containing YAML-hostile characters (colons, quotes)', () => {
+    const lines = serializeCodesBlock([{ code: 'WEIRD:CODE', status: 'active', reward: "say 'hi': +500", source: "a 'source'" }]);
+    expect(lines).toEqual([
+      'codes:',
+      "  - code: 'WEIRD:CODE'",
+      "    reward: 'say ''hi'': +500'",
+      '    status: active',
+      "    source: 'a ''source'''",
+    ]);
+  });
+});

--- a/tests/sync-codes.test.ts
+++ b/tests/sync-codes.test.ts
@@ -7,6 +7,7 @@
  */
 import { describe, expect, test } from 'vitest';
 import {
+  fanOutLocales,
   mergeCodes,
   parseCodesBlock,
   parseCodesCsv,
@@ -92,7 +93,9 @@ describe('parseCodesCsv', () => {
 });
 
 describe('mergeCodes', () => {
-  const existing: CodesEntry[] = [
+  // Factory, not a shared const: mergeCodes mutates entries in place, so a
+  // shared fixture would leak mutations across tests.
+  const makeExisting = (): CodesEntry[] => [
     { code: 'FORGE-2026', reward: '+500 Gold', status: 'active', expiryDate: 'Aug 31' },
     { code: 'FROSTPIKE', reward: '+250 Gold', status: 'expired', expiryDate: 'Aug 21' },
   ];
@@ -109,7 +112,7 @@ describe('mergeCodes', () => {
   });
 
   test('new codes are prepended in CSV order; existing entries keep their order', () => {
-    const { merged, stats } = mergeCodes(existing, [
+    const { merged, stats } = mergeCodes(makeExisting(), [
       row({ code: 'NEW-B' }),
       row({ code: 'NEW-A' }),
     ]);
@@ -119,7 +122,7 @@ describe('mergeCodes', () => {
   });
 
   test('active → expired flips are tracked and the entry is kept in place', () => {
-    const { merged, stats } = mergeCodes(existing, [row({ code: 'FORGE-2026', status: 'expired' })]);
+    const { merged, stats } = mergeCodes(makeExisting(), [row({ code: 'FORGE-2026', status: 'expired' })]);
     expect(stats.expiredFlipped).toEqual(['FORGE-2026']);
     const forge = merged.find((c) => c.code === 'FORGE-2026');
     expect(forge?.status).toBe('expired');
@@ -127,7 +130,7 @@ describe('mergeCodes', () => {
   });
 
   test('empty optional CSV cells keep existing values; provided cells overwrite', () => {
-    const { merged, stats } = mergeCodes(existing, [row({ code: 'FORGE-2026', reward: '+750 Gold' })]);
+    const { merged, stats } = mergeCodes(makeExisting(), [row({ code: 'FORGE-2026', reward: '+750 Gold' })]);
     expect(stats.updated).toEqual(['FORGE-2026']);
     expect(merged[0]).toMatchObject({ reward: '+750 Gold', expiryDate: 'Aug 31' });
     const again = mergeCodes(merged, [row({ code: 'FORGE-2026', reward: '+750 Gold' })]);
@@ -215,5 +218,79 @@ describe('serializeCodesBlock + upsertCodesFrontmatter', () => {
       '    status: active',
       "    source: 'a ''source'''",
     ]);
+  });
+});
+
+describe('CRLF handling', () => {
+  test('CRLF pages parse and upsert preserves the CRLF EOL style', () => {
+    const crlfPage = pageWithCodes(demoBlock).replace(/\n/g, '\r\n');
+    const parsed = parseCodesBlock(crlfPage);
+    if ('error' in parsed) throw new Error(parsed.error);
+    expect(parsed.codes).toHaveLength(2);
+    const out = upsertCodesFrontmatter(crlfPage, parsed.codes, '2026-09-06');
+    if ('error' in out) throw new Error(out.error);
+    expect(out.output).toContain('lastModified: 2026-09-06\r');
+    expect(out.output).not.toMatch(/\r[^\n]/); // every \r is part of a \r\n pair
+    const reparsed = parseCodesBlock(out.output);
+    if ('error' in reparsed) throw new Error(reparsed.error);
+    expect(reparsed.codes).toEqual(parsed.codes);
+  });
+});
+
+describe('CSV hostile-cell rejection', () => {
+  test('embedded newline in a quoted cell is rejected at parse time (would write invalid YAML)', () => {
+    const csv = 'locale,slug,code,status,reward\nen,all-codes,BAD-NL,active,"two\nlines"';
+    const { rows, errors } = parseCodesCsv(csv, LOCALES);
+    expect(rows).toEqual([]);
+    expect(errors.some((e) => e.includes('control character'))).toBe(true);
+  });
+});
+
+describe('schema boundaries', () => {
+  test('expiryDate of exactly 40 chars passes (schema cap)', () => {
+    const csv = `locale,slug,code,expiryDate\nen,all-codes,EDGE40,${'x'.repeat(40)}`;
+    const { rows, errors } = parseCodesCsv(csv, LOCALES);
+    expect(errors).toEqual([]);
+    expect(rows[0]?.expiryDate).toHaveLength(40);
+  });
+});
+
+describe('fanOutLocales', () => {
+  const row = (over: Partial<{ locale: string; slug: string; code: string; reward: string }> = {}) => ({
+    line: 2,
+    locale: 'en',
+    slug: 'all-codes',
+    code: 'NEW-1',
+    status: 'active' as const,
+    reward: '+1 Gold',
+    expiryDate: '',
+    source: '',
+    ...over,
+  });
+
+  test('fills locales that have the page but no explicit row, with a review note', () => {
+    const groups = new Map([['en/all-codes', [row()]]]);
+    const { groups: expanded, notes } = fanOutLocales(groups, ['en', 'ja'], (locale) => locale === 'en' || locale === 'ja');
+    expect([...expanded.keys()].sort()).toEqual(['en/all-codes', 'ja/all-codes']);
+    expect(expanded.get('ja/all-codes')![0]).toMatchObject({ locale: 'ja', code: 'NEW-1', reward: '+1 Gold' });
+    expect(notes[0]).toContain('synced from the "en" row');
+  });
+
+  test('explicit per-locale rows win and produce no fan-out note', () => {
+    const groups = new Map([
+      ['en/all-codes', [row()]],
+      ['ja/all-codes', [row({ locale: 'ja', reward: '翻訳済み報酬' })]],
+    ]);
+    const { groups: expanded, notes } = fanOutLocales(groups, ['en', 'ja'], () => true);
+    expect(expanded.size).toBe(2);
+    expect(expanded.get('ja/all-codes')![0].reward).toBe('翻訳済み報酬');
+    expect(notes).toEqual([]);
+  });
+
+  test('locales without an existing page are skipped (sync never creates pages)', () => {
+    const groups = new Map([['en/all-codes', [row()]]]);
+    const { groups: expanded, notes } = fanOutLocales(groups, ['en', 'ja', 'ko'], (locale) => locale === 'en');
+    expect(expanded.size).toBe(1);
+    expect(notes).toEqual([]);
   });
 });


### PR DESCRIPTION
## 做了什么
roadmap 候选池「管道生成器扩展:codes 同步」的第一步(即 content-pipeline.md v2.1 候选的 `codes-sync` 生成器):新增确定性脚本 `pnpm sync-codes`,把「新增/过期兑换码」从 AI 会话搬进脚本。

## 用法
```bash
pnpm sync-codes                  # 读仓库根 codes-sync.csv / .tsv
pnpm sync-codes my-codes.csv     # 显式文件
pnpm sync-codes --dry-run        # 预览,不写
pnpm sync-codes --locales=en,ja  # 只应用指定语言的行
```
CSV 列:`locale,slug,code,status,reward,expiryDate,source`(后四列可选)。

## 合并语义(与 anvil-update-codes 技能逐条对齐,是它的机械半边)
- 新码**前置**(最新在前);过期翻转但**保留**条目(长尾 "is X still working" SEO)
- 空可选单元格保留现值;全语言同名页同步(码不翻译,reward/source 照搬→提示复查非 en 措辞)
- 目标页必须已存在(同步不建页);lastModified 随写随更
- **all-or-nothing**:全部文件先解析校验,任一失败什么都不写;扁平标量解析器遇未知字段/行内注释/嵌套结构**响亮中止**,绝不盲写

## 实现与验证
- 纯函数下沉 `scripts/lib/sync-codes.ts`(`scripts/lib/delimited.ts` 抽出 CSV/TSV 解析器,bulk-new-posts 同源复用——对照 v2.6.3 apply-rewrites 先例)
- 新增第 12 套件 `tests/sync-codes.test.ts`(14 条:CSV 校验/合并语义/frontmatter 拼接逐字节+幂等);test 133→147
- demo 页真实冒烟:新码前置+已过期判 unchanged,diff 仅 lastModified+新条目
- 八门禁全绿(lint/typecheck 0 错/test 147/check-config/check-content/check-i18n --strict-ui/build/check-links)
- 纯增量,零 fork 行为变更(不涉 e2e 场景)

## 文档同步(一致性铁律)
AGENTS 命令表/手册附录 C 双语(20→21 条命令,description+tldr+速查块三处)/docs/content-pipeline.md 新节+候选标 ✅/PRD 脚本计数 14→15/anvil-update-codes SKILL 批量提示/CHANGELOG [Unreleased]

## 留给维护者拍板
- 管道接入(auto-content.yml 新任务输入 + workflows.test.ts 契约)按候选池原意属后续小版本,本 PR 有意不碰 CI 契约
- 建议版本号:minor(v2.16.0,新功能纯增量)——只建议,不真发版