### PR TITLE
chore(content): demo codes 页 9 月保鲜第二轮——新增 EMBERFALL-2026(en+ja)

### DIFF
--- a/src/content/wiki/en/codes/all-codes.mdx
+++ b/src/content/wiki/en/codes/all-codes.mdx
@@ -3,12 +3,17 @@ title: 'All Working Codes (September 2026)'
 description: 'Every working Anvil Quest code in September 2026, tested daily. Redeem for gold, XP boosts, and exclusive cosmetics before they expire.'
 category: 'codes'
 date: 2026-08-14
-lastModified: 2026-09-07
+lastModified: 2026-09-10
 image: '../../../../assets/covers/codes-cover.png'
 gameVersion: 'v2.5'
 tags: ['codes', 'redeem', 'freebies']
-summary: 'Three Anvil Quest codes are working as of September 7, 2026: ASHENKEEP, NEWPLAYER, and ANVIL-DAWN, which expires September 15. FORGE-2026 (+500 gold) and EMBERBORN (2× XP) expired August 31. Redeem via Settings → Redeem Code in under a minute; this list is re-tested and updated as codes rotate.'
+summary: 'Four Anvil Quest codes are working as of September 10, 2026: new EMBERFALL-2026 (+400 gold), ASHENKEEP, NEWPLAYER, and ANVIL-DAWN, which expires September 15. FORGE-2026 (+500 gold) and EMBERBORN (2× XP) expired August 31. Redeem via Settings → Redeem Code in under a minute; this list is re-tested and updated as codes rotate.'
 codes:
+  - code: EMBERFALL-2026
+    reward: '+400 Gold'
+    status: active
+    expiryDate: 'Sep 30'
+    source: 'Official September newsletter'
   - code: FORGE-2026
     reward: '+500 Gold'
     status: expired

--- a/src/content/wiki/ja/codes/all-codes.mdx
+++ b/src/content/wiki/ja/codes/all-codes.mdx
@@ -3,12 +3,17 @@ title: '現在有効なコード一覧(2026年9月)'
 description: '2026年9月時点で動作する Anvil Quest のコード一覧。毎日検証済み。ゴールド・経験値ブースト・限定コスメと交換できます。'
 category: 'codes'
 date: 2026-08-14
-lastModified: 2026-09-07
+lastModified: 2026-09-10
 image: '../../../../assets/covers/codes-cover.png'
 gameVersion: 'v2.5'
 tags: ['codes', 'redeem', 'freebies']
-summary: '2026年9月7日時点で有効なコードは3個(ASHENKEEP/NEWPLAYER/ANVIL-DAWN)。9月15日に期限が来る ANVIL-DAWN はお早めに。FORGE-2026(ゴールド500)と EMBERBORN(経験値2倍)は8月31日に期限切れ。コードは設定→Redeem Code から1分以内で交換でき、このリストはローテーションに合わせて再検証・更新しています。'
+summary: '2026年9月10日時点で有効なコードは4個(新コード EMBERFALL-2026/ASHENKEEP/NEWPLAYER/ANVIL-DAWN)。9月15日に期限が来る ANVIL-DAWN はお早めに。FORGE-2026(ゴールド500)と EMBERBORN(経験値2倍)は8月31日に期限切れ。コードは設定→Redeem Code から1分以内で交換でき、このリストはローテーションに合わせて再検証・更新しています。'
 codes:
+  - code: EMBERFALL-2026
+    reward: 'ゴールド400'
+    status: active
+    expiryDate: '9月30日'
+    source: '公式9月ニュースレター'
   - code: FORGE-2026
     reward: 'ゴールド500'
     status: expired


### PR DESCRIPTION
## 动机
下周一(09-14)每周保鲜审计将因 codes 页 lastModified(2026-09-07)到达 7d 阈值触发 P0(issue #20 类)。按审计建议的既定实践做一轮保鲜,把阈值推后;同时实战检验 v2.16/v2.17 的 sync-codes 管道。

## 改动(纯 demo 内容,fictional 游戏既定实践)
- **新增码 EMBERFALL-2026**(+400 Gold,9月30日到期,官方 9 月通讯):用 `pnpm sync-codes` 执行——en 一行,fan-out 自动同步 ja 页(新码前置),直接吃自家狗粮
- ja 条目手工本地化(reward/expiryDate/source 对齐全页惯例——fan-out 照搬英文后按输出提示复查,正是设计行为)
- 双语 summary 同步:3→4 码,as-of 9月7日→9月10日
- lastModified → 2026-09-10(两语言同步——#12 教训)

## 顺带发现一个 bug(单独 PR 修复)
sync-codes 的 `todayIso()` 用 **UTC**,而本脚本的主场是凌晨管道(CST 00:00-08:00 UTC 日期还停在昨天)——本次实测写入 09-09、手工纠正为 09-10。修复(todayIso 改本地日期)随后单独 PR。

## 验证
八门禁全绿(check-content/build/test 168/lint/typecheck/check-config/check-i18n --strict-ui/check-links);demo 页 schema 校验由 build 兜底

## 建议版本号
无需独立发版(纯 demo 内容),随下次发版带上即可。