### PR TITLE
fix(scripts): 内容日期戳 UTC→本地日——五处脚本统一收口 lib/today.ts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ pnpm dev              # dev server, http://localhost:4321
 pnpm build            # includes Content schema validation — fails on bad frontmatter; postbuild indexes Pagefind search
 pnpm typecheck        # astro check (0 errors expected)
 pnpm lint             # ESLint (eslint-plugin-astro)
-pnpm test             # Vitest — 12 suites (url, seo, tags, i18n-smoke, content-utils, handbook, workflows, covers, affiliates, prompt, apply-template, sync-codes)
+pnpm test             # Vitest — 14 suites (url, seo, tags, i18n-smoke, content-utils, handbook, workflows, covers, affiliates, prompt, apply-template, sync-codes, community-digest, today)
 pnpm test:e2e         # apply-template real-mode E2E (git archive → scratch copy → pipe answers → assert shape → build; CI job e2e-template runs it; tests the COMMITTED tree)
 pnpm check-config     # scripts/check-config.ts — nav/locale 3-place consistency
 pnpm new-locale       # scripts/new-locale.ts — scaffold a new language

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **内容日期戳 UTC→本地日(五处脚本统一收口)**——`bulk-new-posts` / `sync-codes` / `new-post` / `apply-template` / `refresh-audit` 的「今天」原来都用 `toISOString()`(UTC),凌晨本地管道场景(CST 00:00–08:00)会把**昨天**的日期写进 frontmatter(sync-codes 在 03:10 CST 实测写入 09-09、当天实为 09-10,dogfood 发现)。抽出共享 `scripts/lib/today.ts`(`todayIso()` 按本地日历取日),五处统一替换;`refresh-audit` 在 CI(UTC)下行为不变,本地运行阈值日与用户日历一致。新增第 14 套件 `tests/today.test.ts`(3 条:本地日/零填充/与 UTC 偏差 ≤1 天);顺带修正 AGENTS 命令表套件计数 12→14(v2.18.0 漏更 community-digest,本次发现即修)。
+
 ## [2.18.0] — 2026-09-09
 
 **社群精华页上线（/landing/community + /zh/landing/community，每日 AI 管道供数）+ 24h 只读风险审计闭环：课程评价红线历史清理补漏、digest JSON 契约测试兜底、日报渲染 newest-N 窗口。**

--- a/scripts/apply-template.ts
+++ b/scripts/apply-template.ts
@@ -33,6 +33,7 @@
  */
 
 import * as fs from 'node:fs';
+import { todayIso } from './lib/today';
 import * as path from 'node:path';
 import { createLinePrompt, type LinePrompt } from './lib/prompt';
 import {
@@ -462,7 +463,7 @@ function scaffoldContent(categories: { key: string }[]): number {
 title: "Getting Started with ${titleCase(key)} Guide"
 description: "A starter article for the ${key} category. Replace this scaffold with your real ${key} content — keep the description between 40 and 165 characters for SEO."
 category: "${key}"
-date: ${new Date().toISOString().slice(0, 10)}
+date: ${todayIso()}
 tags: []
 ---
 

--- a/scripts/bulk-new-posts.ts
+++ b/scripts/bulk-new-posts.ts
@@ -35,6 +35,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { isBlankOrComment, parseDelimited } from './lib/delimited';
+import { todayIso } from './lib/today';
 
 const ROOT = process.cwd();
 const CONTENT_BASE = path.resolve(ROOT, 'src/content/wiki');
@@ -88,10 +89,6 @@ function slugify(s: string): string {
     .replace(/[^\p{L}\p{N}\s-]/gu, '')
     .replace(/[\s_-]+/g, '-')
     .replace(/^-+|-+$/g, '');
-}
-
-function todayIso(): string {
-  return new Date().toISOString().slice(0, 10);
 }
 
 /** Minimal RFC-4180-ish delimited parser: shared in scripts/lib/delimited.ts. */

--- a/scripts/lib/today.ts
+++ b/scripts/lib/today.ts
@@ -1,0 +1,15 @@
+/**
+ * Local-calendar date as YYYY-MM-DD.
+ *
+ * Content date stamps (frontmatter date/lastModified, audit "as of") must
+ * follow the USER'S calendar, not UTC: `new Date().toISOString()` silently
+ * rolls back a day for every run between local midnight and 01:00 UTC — and
+ * this repo's automations are night owls (03:00 CST runs write yesterday's
+ * date for 8 hours every night). Found by dogfooding sync-codes at 03:10 CST.
+ */
+export function todayIso(): string {
+  const d = new Date();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${d.getFullYear()}-${mm}-${dd}`;
+}

--- a/scripts/new-post.ts
+++ b/scripts/new-post.ts
@@ -11,6 +11,7 @@
  */
 
 import * as fs from 'node:fs';
+import { todayIso } from './lib/today';
 import * as path from 'node:path';
 import { createLinePrompt } from './lib/prompt';
 
@@ -51,9 +52,7 @@ function slugify(s: string): string {
     .replace(/^-+|-+$/g, '');
 }
 
-function todayIso(): string {
-  return new Date().toISOString().slice(0, 10);
-}
+
 
 async function main() {
   const rl = createLinePrompt();

--- a/scripts/refresh-audit.ts
+++ b/scripts/refresh-audit.ts
@@ -20,6 +20,7 @@
  */
 
 import * as fs from 'node:fs';
+import { todayIso } from './lib/today';
 import * as path from 'node:path';
 
 const ROOT = process.cwd();
@@ -92,7 +93,7 @@ for (const file of files) {
 
 items.sort((a, b) => a.days - b.days);
 
-const today = new Date().toISOString().slice(0, 10);
+const today = todayIso();
 const lines: string[] = [];
 lines.push(`## Content freshness audit (${today})`);
 lines.push('');

--- a/scripts/sync-codes.ts
+++ b/scripts/sync-codes.ts
@@ -36,6 +36,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { todayIso } from './lib/today';
 import {
   fanOutLocales,
   mergeCodes,
@@ -75,10 +76,6 @@ const LOCALE_FILTER = (() => {
   }
   return list;
 })();
-
-function todayIso(): string {
-  return new Date().toISOString().slice(0, 10);
-}
 
 // Same config-reading helper as bulk-new-posts.ts (regex-read, no imports).
 function readLocales(): string[] {

--- a/tests/today.test.ts
+++ b/tests/today.test.ts
@@ -1,0 +1,30 @@
+/**
+ * todayIso unit tests — the shared local-calendar date stamp behind every
+ * content-writing script (bulk-new-posts / sync-codes / new-post /
+ * apply-template / refresh-audit). Regression: the previous inline
+ * implementations used `toISOString()` (UTC), so nightly local runs wrote
+ * YESTERDAY's date into frontmatter for the whole pre-01:00-UTC window —
+ * caught by dogfooding sync-codes at 03:10 CST (wrote 09-09, was 09-10).
+ */
+import { describe, expect, test } from 'vitest';
+import { todayIso } from '../scripts/lib/today';
+
+describe('todayIso', () => {
+  test('returns the LOCAL calendar date, not the UTC one', () => {
+    const d = new Date();
+    const local = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    expect(todayIso()).toBe(local);
+  });
+
+  test('is zero-padded YYYY-MM-DD', () => {
+    expect(todayIso()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  test('never disagrees with toISOString by more than the UTC offset (sanity)', () => {
+    // The whole point of the fix: local and UTC dates may differ by one day,
+    // never more — guards against a future regression to epoch-based math.
+    const utc = new Date().toISOString().slice(0, 10);
+    const days = (s: string) => Date.parse(`${s}T00:00:00Z`) / 86_400_000;
+    expect(Math.abs(days(todayIso()) - days(utc))).toBeLessThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
## 根因(狗粮发现)
昨夜内容保鲜批用 `pnpm sync-codes` 时,03:10 CST 实测 frontmatter 被写入 **09-09**(当天实为 09-10):五个内容脚本的「今天」都用 `toISOString()`(UTC),UTC+8 的 0:00–8:00 窗口整夜错一天——而本仓库的自动化恰是夜猫子(03:00 CST 管道)。

## 修复
- 抽共享 `scripts/lib/today.ts`:`todayIso()` 按本地日历取日,注释写明为什么不能 UTC;
- 五处统一替换:`bulk-new-posts` / `sync-codes` / `new-post` / `apply-template`(内容戳)+ `refresh-audit`(比对日;CI 跑在 UTC 行为不变,本地运行阈值日回归用户日历);
- 新增第 14 套件 `tests/today.test.ts`(3 条:本地日/零填充/与 UTC 偏差 ≤1 天防回归);
- 顺带修 AGENTS 命令表套件计数 12→14:实际 13 套件(v2.18.0 加 community-digest 时漏更,本次发现即修),本 PR 后 14。

## 验证
八门禁全绿,测试 168→**171**;五脚本 grep 确认无残留 toISOString。

## 建议版本号
patch(**v2.18.1**,bug fix 零新功能)。只建议,不真发版。