### PR TITLE
fix(changelog): 补回 v2.18.1 发版吞掉的 [Unreleased] 段与 compare 指针

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to AnvilWiki are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [2.18.1] — 2026-09-10
 
 **文档一致性修复批 + 内容日期戳 UTC→本地日修复：七天「行为 vs 文档」漂移审计全部发现当日闭环——PRD 更新记录表停更 8 版补齐、开发手册管道课接上任务选择器、发版清单补齐无门禁纪律步；顺带根治五处脚本凌晨把昨日日期写进 frontmatter 的错写。**
@@ -1015,6 +1017,7 @@ This release covers everything since v0.2.0: the full PRD roadmap (v1.1–v2.0) 
 - Docs: PRD (1600+ lines), deployment, apply-template (4-step guide), content-format, seo, ads, migration-from-nextjs
 - Build: 27 pages, typecheck 0 errors
 
+[Unreleased]: https://github.com/PNGTRID/AnvilWiki/compare/v2.18.1...HEAD
 [2.18.1]: https://github.com/PNGTRID/AnvilWiki/compare/v2.18.0...v2.18.1
 [2.18.0]: https://github.com/PNGTRID/AnvilWiki/compare/v2.17.0...v2.18.0
 [2.17.0]: https://github.com/PNGTRID/AnvilWiki/compare/v2.16.1...v2.17.0


### PR DESCRIPTION
## 根因(每日巡检第 1 步抓到)
v2.18.1 发版时把 `## [Unreleased]` 段直接改名为 `## [2.18.1]`,**没有补回新的空 Unreleased 段**,引用区的 `[Unreleased]:` compare 链接行也一并被删。这正是 [2.6.2] 记录的「连续 6 版漏更」同源事故点,历史上第 5 次出现(发版 SOP 有清单但人工执行仍会漏)。

## 修复(3 行)
- `## [Unreleased]` 空段归位(2.18.1 之上)
- `[Unreleased]: compare/v2.18.1...HEAD` 指针归位

## 验证
纯 CHANGELOG 3 行;八门禁全绿(test 171/check-links/build 等)。

## 建议
无版本号含义(下个版本发版时自然覆盖);合并即闭环。