### PR TITLE
chore(community-digest): 2026-09-12 社群精华更新（0 条+极薄日报）

### DIFF
--- a/src/components/landing/community-digest.json
+++ b/src/components/landing/community-digest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "updated": "2026-09-11",
+  "updated": "2026-09-12",
   "since": "2026-08-16",
   "categories": [
     {
@@ -849,6 +849,14 @@
   ],
   "daily": [
     {
+      "date": "2026-09-12",
+      "summary": "极安静日：仅群友分享 codex 重置倒计时工具（whenreset.dev，支持 webhook），晚间主理人提及修复若干 bug。",
+      "topics": [
+        "codex重置",
+        "工具分享"
+      ]
+    },
+    {
       "date": "2026-09-11",
       "summary": "重要修正：实测广告组件加 sandbox 后 rra 收益骤降（平台反制），推翻此前无条件加 sandbox 的共识；另有两则广告/GSC 答疑与一个 GPT-6 工具站复刻实操。",
       "topics": [
@@ -1104,6 +1112,27 @@
     }
   ],
   "reports": [
+    {
+      "date": "2026-09-12",
+      "stats": {
+        "messages": 17,
+        "speakers": 7,
+        "peakHour": "16:00-17:00",
+        "heat": "冷清"
+      },
+      "quotes": [],
+      "takeaways": [],
+      "qa": [],
+      "resources": [
+        {
+          "title": "codex 重置倒计时工具",
+          "note": "whenreset.dev/zh-cn——Codex 订阅额度重置时间倒计时，支持 webhook 提醒",
+          "by": "鱼头 🌊"
+        }
+      ],
+      "faq": [],
+      "topics": []
+    },
     {
       "date": "2026-09-11",
       "stats": {


### PR DESCRIPTION
## 当日概览

极安静日：全天 **17 条 / 7 人发言 / 高峰 16:00-17:00 / 冷清**，无达分类门槛的内容。按 spec 第 6 条：daily 无空洞、日报出极薄版、游标推进至 2026-09-12。✅ 写盘已带尾换行（第 9 条契约测试）。

## 分类新增（0 条）

无达门槛内容；日报仅收录资源分享 1 条。

---

## ⚠️ 属主维度（仅主理人跟进用，未公开）

### 未解决问题
本期无新增（存量 4 条仍未决：Adsterra 恢复/工具站 AdSense/heic to png/广告平台推荐）。

### 产品反馈
本期无。

### 活跃成员
- 鱼头 🌊：分享 codex 重置倒计时工具 whenreset.dev（支持 webhook），获群友好评

### 新人动态
三次入群事件，邀请消息均为模板占位（无可解析名单）。

### 情绪与口碑信号
本期无强信号。

### 遗留待裁决
rra 内容公开分歧（艾米，09-08）仍待主理人裁决。

### 备注
主理人 23:01 发言『更新一些bug』（附图无细节）——恰在抓取边界，明晚运行会重写 09-12 日报为终稿时归置。