### PR TITLE
test(agents): 套件清单一致性门禁——AGENTS 计数漂移变 CI 红灯

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ pnpm dev              # dev server, http://localhost:4321
 pnpm build            # includes Content schema validation — fails on bad frontmatter; postbuild indexes Pagefind search
 pnpm typecheck        # astro check (0 errors expected)
 pnpm lint             # ESLint (eslint-plugin-astro)
-pnpm test             # Vitest — 16 suites (url, seo, tags, i18n-smoke, content-utils, handbook, workflows, covers, affiliates, prompt, apply-template, sync-codes, community-digest, today, redirects, changelog)
+pnpm test             # Vitest — 17 suites (url, seo, tags, i18n-smoke, content-utils, handbook, workflows, covers, affiliates, prompt, apply-template, sync-codes, community-digest, today, redirects, changelog, agents-consistency)
 pnpm test:e2e         # apply-template real-mode E2E (git archive → scratch copy → pipe answers → assert shape → build; CI job e2e-template runs it; tests the COMMITTED tree)
 pnpm check-config     # scripts/check-config.ts — nav/locale 3-place consistency
 pnpm new-locale       # scripts/new-locale.ts — scaffold a new language

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **AGENTS.md 套件清单一致性测试(第 17 套件 tests/agents-consistency.test.ts)**——命令表的「N suites (a, b, …)」钉到实际 `tests/` 目录:套件增删漏更 AGENTS 即 CI 变红。计数十天漂三次(12→v2.18.0 漏更 community-digest→14→16),而 AGENTS.md 每个智能体会话都会加载,过期清单天天误导;自 #33(CHANGELOG 契约门禁)复制形态的第二个 meta 一致性门禁。AGENTS 套件计数 16→17 同步。
+
 ## [2.19.0] — 2026-09-12
 
 ### Added

--- a/src/components/landing/community-digest.json
+++ b/src/components/landing/community-digest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "updated": "2026-09-11",
+  "updated": "2026-09-12",
   "since": "2026-08-16",
   "categories": [
     {
@@ -849,6 +849,14 @@
   ],
   "daily": [
     {
+      "date": "2026-09-12",
+      "summary": "极安静日：仅群友分享 codex 重置倒计时工具（whenreset.dev，支持 webhook），晚间主理人提及修复若干 bug。",
+      "topics": [
+        "codex重置",
+        "工具分享"
+      ]
+    },
+    {
       "date": "2026-09-11",
       "summary": "重要修正：实测广告组件加 sandbox 后 rra 收益骤降（平台反制），推翻此前无条件加 sandbox 的共识；另有两则广告/GSC 答疑与一个 GPT-6 工具站复刻实操。",
       "topics": [
@@ -1104,6 +1112,27 @@
     }
   ],
   "reports": [
+    {
+      "date": "2026-09-12",
+      "stats": {
+        "messages": 17,
+        "speakers": 7,
+        "peakHour": "16:00-17:00",
+        "heat": "冷清"
+      },
+      "quotes": [],
+      "takeaways": [],
+      "qa": [],
+      "resources": [
+        {
+          "title": "codex 重置倒计时工具",
+          "note": "whenreset.dev/zh-cn——Codex 订阅额度重置时间倒计时，支持 webhook 提醒",
+          "by": "鱼头 🌊"
+        }
+      ],
+      "faq": [],
+      "topics": []
+    },
     {
       "date": "2026-09-11",
       "stats": {

--- a/tests/agents-consistency.test.ts
+++ b/tests/agents-consistency.test.ts
@@ -1,0 +1,40 @@
+/**
+ * AGENTS.md suite-count consistency — the commands table claims "N suites
+ * (a, b, …)"; this pins the claim to reality. The count drifted 3× in ten
+ * days (12 → missed the v2.18.0 community-digest addition → 14 → 16), and
+ * AGENTS.md is loaded into every agent session, so a stale list quietly
+ * misleads daily. Adding a suite without updating AGENTS.md now goes red.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, test } from 'vitest';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const agents = readdirSync(join(root, 'tests'))
+  .filter((f) => f.endsWith('.test.ts'))
+  .map((f) => f.replace(/\.test\.ts$/, ''))
+  .sort();
+
+describe('AGENTS.md suite-list consistency', () => {
+  const line = readAgentsLine();
+
+  test('the commands table quotes every suite that exists — no more, no fewer', () => {
+    expect(line, 'AGENTS.md `pnpm test` line not found').toBeDefined();
+    const claimed = line!.match(/\(([^)]+)\)/)![1].split(',').map((s) => s.trim()).sort();
+    expect(claimed).toEqual(agents);
+  });
+
+  test('the quoted count matches the list', () => {
+    const count = Number(line!.match(/Vitest — (\d+) suites/)?.[1]);
+    expect(count).toBe(agents.length);
+  });
+});
+
+function readAgentsLine(): string | undefined {
+  const text = readAgentsText();
+  return text.match(/pnpm test\s+# Vitest — .*/)?.[0];
+}
+function readAgentsText(): string {
+  return readFileSync(join(root, 'AGENTS.md'), 'utf8');
+}


### PR DESCRIPTION
## 动机(甲级:测试加固,零行为变更)
AGENTS.md 命令表的「Vitest — N suites (…)」十天漂了三次:12 → v2.18.0 加 community-digest 漏更 → 14 → 16。AGENTS.md 是每个智能体会话自动加载的指令文件,过期的套件清单等于天天误导 AI 和人。昨天 #33 把 CHANGELOG 指针纪律变成了门禁,效果经 v2.19.0 发版首考验证——本 PR 复制该形态到第二个 meta 一致性点。

## 方案
新增第 17 套件 `tests/agents-consistency.test.ts`(2 条):命令表引用的套件名集合必须与 `tests/` 实际文件**集合相等**(不多不少),且计数与清单一致。套件增删漏更 AGENTS → CI 红。

## 验证
- 负向验证天然发生:实现中途 AGENTS 尚列 16 而实际 17 → 两条全红(设计行为);补齐后绿;
- 八门禁全绿,测试 181→**183**;AGENTS 计数 16→17 同步。

## 让谁省了哪步工
发版人/加套件的人:忘改清单 CI 兜底;每日巡检:该人工比对项退役。

## 建议版本号
patch(**v2.19.1**,纯测试加固零行为变更)。只建议,不真发版。